### PR TITLE
Updated to latest distel with our patches, adding missing elisp/erl files

### DIFF
--- a/elisp/distel-ie.el
+++ b/elisp/distel-ie.el
@@ -1,0 +1,234 @@
+;;;
+;;; distel-ie - an interactive erlang shell
+;;;
+;;; Some of the code has shamelessly been stolen from Luke Gorrie
+;;; [luke@bluetail.com] - ripped from its elegance and replaced by bugs.
+;;; It just goes to show that you can't trust anyone these days. And
+;;; as if that wasn't enough, I'll even blame Luke: "He _made_ me do it!"
+;;;
+;;; So, without any remorse, I hereby declare this code to be:
+;;;
+;;; copyright (c) 2002 david wallin [david.wallin@ul.ie].
+;;;
+;;; (it's probably going to be released onto an unexpecting public under
+;;;  some sort of BSD license).
+
+(eval-when-compile (require 'cl))
+(require 'erlang)
+(require 'erl)
+
+(make-variable-buffer-local
+ (defvar erl-ie-node nil
+   "Erlang node that the session is hosted on."))
+
+;;
+;; erl-ie-session
+
+(defun erl-ie-session (node)
+  "Return the erl-ie-session for NODE, creating it if necessary."
+  (interactive (list (erl-ie-read-nodename)))
+
+  (or (get-buffer (erl-ie-buffer-name node))
+      (erl-ie-create-session node)))
+
+(defun erl-ie-create-session (node)
+  (with-current-buffer (get-buffer-create (erl-ie-buffer-name node))
+    (insert "\
+%%% Welcome to the Distel Interactive Erlang Shell.
+%%
+%% C-j evaluates an expression and prints the result in-line.
+%% C-M-x evaluates a whole function definition.
+
+")
+    (push-mark (point) t)
+
+    (erlang-mode)
+    (erl-session-minor-mode 1)
+    (setq erl-ie-node node)
+
+    ;; hiijack stdin/stdout :
+    (let ((output-buffer (current-buffer)))
+      (setq erl-group-leader
+	    (erl-spawn (&erl-ie-group-leader-loop output-buffer))))
+
+    (erl-ie-ensure-registered node)
+
+    (current-buffer)))
+
+(defun erl-ie-read-nodename ()
+  "Get the node for the session, either from buffer state or from the user."
+  (or erl-ie-node (erl-target-node)))
+
+(defun erl-ie-buffer-name (node)
+  (format "*ie session <%S>*" node))
+
+;;
+;; erl-ie-ensure-registered
+
+(defun erl-ie-ensure-registered (node)
+  (interactive (list (erl-ie-read-nodename)))
+  (erl-spawn
+    (erl-send-rpc node 'distel_ie 'ensure_registered '())))
+
+
+(defun erl-ie-eval-expression (node)
+  (interactive (list (erl-ie-read-nodename)))
+  (erl-ie-read-nodename)
+  (let ((end (point))
+	(beg (save-excursion
+	       (loop do (re-search-backward "^$")
+		     while (looking-at "end"))
+	       (point))))
+    (erl-ie-evaluate beg end node t)))
+
+(defun erl-ie-eval-defun (node)
+  (interactive (list (erl-ie-read-nodename)))
+  (erl-ie-read-nodename)
+  (let* ((beg (save-excursion (erlang-beginning-of-function)
+			      (point)))
+	 (end (save-excursion (goto-char beg)
+			      (erlang-end-of-function)
+			      (point))))
+    (erl-ie-evaluate beg end node)))
+
+;;
+;; erl-ie-evaluate
+;;
+;; this is doomed to fail, can end be the smaller value ?
+;; want to change to (interactive "r") somehow ...
+
+(defun erl-ie-evaluate (start end node &optional inline)
+  "Evaluate region START to END on NODE.
+The marked region can be a function definition, a function 
+call or an expression."
+  (interactive (list
+		(region-beginning)
+		(region-end)
+		(erl-ie-read-nodename)))
+
+  (let* ((string (buffer-substring-no-properties start end))
+	 (buffer (current-buffer)))
+    (erl-spawn
+      (erl-send (tuple 'distel_ie node)
+		(tuple 'evaluate erl-self string))
+      
+      (message "Sent eval request..")
+
+      ;; move cursor to after the marked region
+      (goto-char (min (point-max) (1+ end)))
+      (erl-receive (buffer inline)
+	  ((['ok value]
+	    (if inline
+		(with-current-buffer buffer
+		  ;; Clear "Sent eval request.." message
+		  (message "")
+	      
+		  (let ((my-point (point)))
+                    (unless (looking-at "^")
+                      (end-of-line)
+                      (insert "\n"))
+
+                    (let ((beg (point)))
+		    ;; Insert value, indent all lines of it 4 places,
+		    ;; then draw a " => " at the start.
+                      (insert value)
+                      (save-excursion (indent-rigidly beg (point) 5)
+                                      (goto-char beg)
+                                      (delete-region (point) (+ (point) 5))
+                                      (insert " -:-> ")))
+                    (insert "\n")
+                    (goto-char my-point)
+                    (push-mark (point) t)))
+	      (display-message-or-view (format "Result: %s" value)
+				       "*Evaluation Result*")))
+	   
+	   (['msg msg]
+	    (with-current-buffer buffer
+	      (message msg)))
+	   
+	   (['error reason]
+	    (with-current-buffer buffer
+	      
+	      ;; TODO: should check the buffer for first non-whitespace
+	      ;; before we do:
+	      (newline 1)
+	      (insert "Error: ") (insert reason) (newline 1)))
+	   
+	   (other
+	    (message "Unexpected: %S" other)))))))
+
+
+(defun erl-ie-xor (a b)
+  "Boolean exclusive or of A and B."
+  (or (and a (not b))
+      (and b (not a))))
+
+;;
+;; &erl-ie-group-leader-loop
+
+(defun &erl-ie-group-leader-loop (buf)
+  (erl-receive (buf)
+      ((['put_chars s]
+	(with-current-buffer buf
+	  (insert s))))
+    (&erl-ie-group-leader-loop buf)))
+
+
+;;
+;; erl-ie-show-session
+
+(defun erl-ie-show-session (node)
+  "Show the session for NODE, creating if necessary."
+  (interactive (list (erl-ie-read-nodename)))
+  (switch-to-buffer (erl-ie-session node)))
+
+;;
+;; erl-ie-copy-buffer-to-session
+
+(defun erl-ie-copy-buffer-to-session (node)
+  "Open a distel_ie session on NODE with the content of the current buffer.
+The content is pasted at the end of the session buffer.  This can be useful
+for debugging a file without ruining the content by mistake."
+  (interactive (list (erl-ie-read-nodename)))
+  (let ((cloned-buffer (buffer-string)))
+
+    (with-current-buffer (erl-ie-session node)
+      (goto-char (point-max))
+      (insert cloned-buffer))
+    (erl-ie-popup-buffer node)))
+
+;;
+;; erl-ie-copy-region-to-session
+
+(defun erl-ie-copy-region-to-session (start end node)
+  "Open a distel_ie session on NODE with the content of the region.
+The content is pasted at the end of the session buffer.  This can be useful
+for debugging a file without ruining the content by mistake."
+  (interactive (list
+		(region-beginning)
+		(region-end)
+		(erl-ie-read-nodename)))
+  (let ((cloned-region (buffer-substring-no-properties start end)))
+
+    (with-current-buffer (erl-ie-session node)
+      (goto-char (point-max))
+      (set-mark (point))		; so the region will be right
+      (insert cloned-region))
+    (erl-ie-popup-buffer node)))
+
+
+(defun erl-ie-popup-buffer (node)
+  (switch-to-buffer (erl-ie-session node)))
+
+;; ------------------------------------------------------------
+;; Session minor mode.
+
+(define-minor-mode erl-session-minor-mode
+  "Minor mode for Distel Interactive Sessions."
+  nil
+  nil
+  '(("\C-j"    . erl-ie-eval-expression)
+    ("\C-\M-x" . erl-ie-eval-defun)))
+
+(provide 'distel-ie)
+

--- a/elisp/distel.el
+++ b/elisp/distel.el
@@ -1,0 +1,282 @@
+;;; distel.el --- Top-level of distel package, loads all subparts
+
+;; Prerequisites
+(require 'erlang)
+(require 'easy-mmode)
+
+(provide 'distel)
+
+;; Customization
+
+(defgroup distel '()
+  "Distel and erlang-extended-mode development tools."
+  :group 'tools)
+
+(defcustom distel-tags-compliant nil
+  "Tags compliant, i.e. let M-. ask for confirmation."
+  :type 'boolean
+  :group 'distel)
+
+(defcustom distel-inhibit-backend-check nil
+  "Don't check for the 'distel' module when we connect to new nodes."
+  :type 'boolean
+  :group 'distel)
+
+;; Compatibility with XEmacs
+(unless (fboundp 'define-minor-mode)
+  (defalias 'define-minor-mode 'easy-mmode-define-minor-mode))
+
+;; Distel modules
+
+(require 'erl)
+(require 'erl-service)
+(require 'edb)
+
+(require 'distel-ie)
+
+(defun distel-setup ()
+  (add-hook 'erlang-mode-hook 'distel-erlang-mode-hook))
+
+(defun distel-erlang-mode-hook ()
+  "Function to enable the Distel extensions to Erlang mode.
+You can add this to `erlang-mode-hook' with:
+  (add-hook 'erlang-mode-hook 'distel-erlang-mode-hook)"
+  (erlang-extended-mode t))
+
+;; Extended feature key bindings (C-c C-d prefix)
+
+(define-minor-mode erlang-extended-mode
+  "Extensions to erlang-mode for communicating with a running Erlang node.
+
+These commands generally communicate with an Erlang node. The first
+time you use one, you will be prompted for the name of the node to
+use. This name will be cached for future commands. To override the
+cache, give a prefix argument with C-u before using the command.
+\\<erlang-extended-mode-map>
+
+\\[erl-choose-nodename]	- Set Erlang nodename.
+\\[erl-ping]	- Check connection between Emacs and Erlang.
+
+\\[erl-find-source-under-point]		- Jump from a function call to its definition.
+\\[erl-find-source-unwind]		- Jump back from a function definition (multi-level).
+
+\\[erl-reload-module]	- (Re)load an Erlang module.
+\\[erl-reload-modules]	- Reload all Erlang modules that are out of date.
+\\[erl-find-module]	- Find a module.
+\\[erl-who-calls]	- Who calls function under point.
+
+\\[erl-process-list]	- List all Erlang processes (\"pman\").
+\\[edb-toggle-interpret]	- Toggle debug interpreting of the module.
+C-c C-d b/\\[edb-toggle-breakpoint]	- Toggle a debugger breakpoint at the current line.
+\\[edb-monitor]	- Popup the debugger's process monitor buffer.
+\\[edb-synch-breakpoints]	- Synchronizes current breakpoints to erlang.
+\\[edb-save-dbg-state]	- Save set of interpreted modules and breakpoints.
+\\[edb-restore-dbg-state]	- Restore saved set of interpreted modules and breakpoints.
+
+\\[erl-eval-expression]	- Evaluate an erlang expression from the minibuffer.
+\\[erl-ie-show-session]	- Create an interactive \"session\" buffer.
+
+\\[erl-complete]		- Complete a module or remote function name.
+\\[erl-refactor-subfunction]	- Refactor expressions in the region as a new function.
+
+\\[erl-find-sig-under-point]	- Show the signature for the function under point.
+\\[erl-find-doc-under-point]	- Show the HTML documentation for the function under point.
+\\[erl-find-sig]	- Show the signature for a function.
+\\[erl-find-doc]	- Show the HTML documentation for a function.
+\\[erl-fdoc-describe]	- Describe a function with fdoc.
+\\[erl-fdoc-apropos]	- Describe functions matching a regexp with fdoc.
+
+\\[fprof]	- Profile (with fprof) an expression from the minibuffer.
+\\[fprof-analyse]	- View profiler results from an \"fprof:analyse\" file.
+
+ \"fdoc\" works by looking at the source code. The HTML doc functions
+needs the OTP HTML docs to be installed. who-calls makes use of
+xref, and can take quite some time to initialize.
+
+  Most commands that pop up new buffers will save your original
+window configuration, so that you can restore it by pressing
+'q'. Use `describe-mode' (\\[describe-mode]) on any Distel buffer
+when you want to know what commands are available. To get more
+information about a particular command, use \"\\[describe-key]\"
+followed by the command's key sequence. For general information
+about Emacs' online help, use \"\\[help-for-help]\".
+"
+  nil
+  nil
+  ;; Fake keybinding list just to get the keymap created.
+  ;;
+  ;; define-minor-mode is very inconvenient for redefining keybindings
+  ;; so we do that by hand, below.
+  '(("\M-." 'undefined)))
+
+(defconst distel-keys
+  '(("\C-c\C-di" edb-toggle-interpret)
+    ("\C-x "     edb-toggle-breakpoint)
+    ("\C-c\C-db" edb-toggle-breakpoint)
+    ("\C-c\C-ds" edb-synch-breakpoints)
+    ("\C-c\C-dS" edb-save-dbg-state)
+    ("\C-c\C-dR" edb-restore-dbg-state)
+    ("\C-c\C-dm" edb-monitor)          
+    ("\C-c\C-d:" erl-eval-expression)
+    ("\C-c\C-dL" erl-reload-module)
+    ("\C-c\C-dr" erl-reload-modules)
+    ("\C-c\C-dp" fprof)
+    ("\C-c\C-dP" fprof-analyse)
+    ("\C-c\C-d." erl-find-source-under-point)
+    ("\C-c\C-d," erl-find-source-unwind)
+    ("\C-c\C-dl" erl-process-list)
+    ("\C-\M-i"   erl-complete)	; M-TAB
+    ("\M-?"      erl-complete)	; Some windowmanagers hijack M-TAB..
+    ("\C-c\C-de" erl-ie-show-session)
+    ("\C-c\C-df" erl-refactor-subfunction)
+    ("\C-c\C-dF" erl-find-module)
+    ("\C-c\C-dg" erl-ping)
+    ("\C-c\C-dA" erl-show-arglist)
+    ("\C-c\C-dh" erl-find-doc-under-point)
+    ("\C-c\C-dH" erl-find-doc)
+    ("\C-c\C-dz" erl-find-sig-under-point)
+    ("\C-c\C-dZ" erl-find-sig)
+    ("\C-c\C-dd" erl-fdoc-describe)
+    ("\C-c\C-da" erl-fdoc-apropos)
+    ("\C-c\C-dw" erl-who-calls)
+    ("\C-c\C-dn" erl-choose-nodename)
+    ("("         erl-openparen)
+    ;; Possibly "controversial" shorter keys
+    ("\M-."      erl-find-source-under-point)	; usually `find-tag'
+    ("\M-*"      erl-find-source-unwind) ; usually `pop-tag-mark'
+    ("\M-,"      erl-find-source-unwind) ; usually `tags-loop-continue'
+    ;;("\M-/"      erl-complete) ; usually `dabbrev-expand'
+    )
+  "Keys to bind in distel-mode-map.")
+
+(defun distel-bind-keys ()
+  "Bind `distel-keys' in `erlang-extended-mode-map'."
+  (interactive)
+  (dolist (spec distel-keys)
+    (define-key erlang-extended-mode-map (car spec) (cadr spec))))
+
+(distel-bind-keys)
+
+;; Setup mode-line info for erlang-extended-mode
+;;
+;; NB: Would use the LIGHTER argument for define-minor-mode, but it's
+;; not working portably: my copy of Emacs21 disagrees with emacs20 and
+;; xemacs on whether it should be quoted.
+
+(defvar distel-modeline-node nil
+  "When non-nil the short name of the currently connected node.")
+
+(add-to-list 'minor-mode-alist
+	     '(erlang-extended-mode
+	       (" EXT"
+                (distel-modeline-node (":" distel-modeline-node) "")
+                (edb-module-interpreted "<interpreted>" ""))))
+
+(add-hook 'erlang-extended-mode-hook
+	  '(lambda ()
+	     (if erlang-extended-mode
+		 (distel-init)
+	       (distel-finish))))
+
+(defun distel-init ()
+  (setq erlang-menu-items
+	(erlang-menu-add-below 'distel-menu-items
+			       'erlang-menu-compile-items
+			       erlang-menu-items))
+  (erlang-menu-init))
+
+(defun distel-finish ()
+  (setq erlang-menu-items
+	(erlang-menu-delete 'distel-menu-items erlang-menu-items))
+  (erlang-menu-init))
+  
+(defvar distel-menu-items
+  '(nil
+    ("Distel"
+     (("List all erlang processes" erl-process-list)
+      ("Eval an erlang expression" erl-eval-expression)
+      ("Reload an erlang module" erl-reload-module)
+      ("Reload all changed erlang modules" erl-reload-modules)
+      nil
+      ("Profile an erlang expression" fprof)
+      ("View profiler results" fprof-analyse)
+      nil
+      ("Toggle debug interpreting of the module" edb-toggle-interpret)
+      ("Toggle a breakpoint at current line" edb-toggle-breakpoint)
+      ("Synchronizes current breakpoints to erlang" edb-synch-breakpoints)
+      ("Save debugger state" edb-save-dbg-state)
+      ("Restore debugger state" edb-restore-dbg-state)
+      ("Popup the debugger process monitor" edb-monitor)
+      nil
+      ("Create an interactive erlang session buffer" erl-ie-show-session)
+      nil
+      ("Specify which node to connect to" erl-choose-nodename)
+      )))
+  "*Description of the Distel menu used by Erlang Extended mode.
+
+Please see the documentation of `erlang-menu-base-items'.")
+
+
+;; Bug reportage
+
+(defvar distel-bugs-address "distel-hackers@lists.sourceforge.net"
+  "Email address to send distel bugs to.")
+
+(eval-when-compile (require 'font-lock))
+
+(defun report-distel-problem (summary)
+  "Report a bug to the distel-hackers mailing list."
+  (interactive (list (read-string "One-line summary: ")))
+  (compose-mail distel-bugs-address
+		(format "PROBLEM: %s" summary))
+  (require 'font-lock)
+  (insert (propertize "\
+;; Distel bug report form.
+;;
+;; This is an email message buffer for you to fill in information
+;; about your problem. When finished, you can enter \"C-c C-c\" to
+;; send the report to the distel-hackers mailing list - or update the
+;; 'To: ' header line to send it somewhere else.
+;;
+;; Please describe the problem in detail in this blank space:
+
+"
+		      'face font-lock-comment-face))
+  (save-excursion
+    (insert (propertize "\
+
+
+;; Below is some automatically-gathered debug information. Please make
+;; sure it doesn't contain any secrets that you don't want to send. If
+;; you decide to censor it or have any other special notes, please
+;; describe them here:
+
+
+
+"
+			'face font-lock-comment-face))
+    (insert "[ ---- Automatically gathered trace information ---- ]\n\n")
+    (insert (format "Emacs node name: %S\n\n" erl-node-name))
+    (insert (format "Node of most recent command: %S\n\n" erl-nodename-cache))
+    (insert "Recent *Messages*:\n")
+    (distel-indented-insert (distel-last-lines "*Messages*" 15) 2)
+    (insert "\n\n")
+    (when erl-nodename-cache
+      (insert (format "Recent interactions with %S:\n" erl-nodename-cache))
+      (distel-indented-insert (distel-last-lines
+			       (format "*trace %S*" erl-nodename-cache) 50)
+			      2))
+    (insert "\n\nThe End.\n\n")))
+
+(defun distel-last-lines (buffer n)
+  (with-current-buffer buffer
+    (save-excursion
+      (goto-char (point-max))
+      (forward-line (- n))
+      (buffer-substring (point) (point-max)))))
+
+(defun distel-indented-insert (string level)
+  (let ((pos (point)))
+    (insert string)
+    (indent-rigidly pos (point) level)))
+

--- a/elisp/edb.el
+++ b/elisp/edb.el
@@ -1,0 +1,890 @@
+;;; edb.el --- Erlang debugger front-end
+
+(eval-when-compile (require 'cl))
+(require 'erl)
+(require 'erl-service)
+(require 'erlang)
+(require 'ewoc)
+
+(eval-and-compile
+  (autoload 'erlang-extended-mode "distel"))
+
+(when (featurep 'xemacs)
+  (require 'overlay))
+
+;; Hack for XEmacs compatibility..
+(unless (fboundp 'line-beginning-position)
+  (defalias 'line-beginning-position 'point-at-bol))
+
+;; ----------------------------------------------------------------------
+;; Configurables
+
+(defcustom edb-popup-monitor-on-event t
+  "*Automatically popup the monitor on interesting events.
+An interesting event is an unattached process reaching a breakpoint,
+or an attached process exiting."
+  :type 'boolean
+  :group 'distel)
+
+(defface edb-breakpoint-face
+  `((((type tty) (class color))
+     (:background "red" :foreground "black"))
+    (((type tty) (class mono))
+     (:inverse-video t))
+    (((class color) (background dark))
+     (:background "darkred" :foreground "white"))
+    (((class color) (background light))
+     (:background "tomato" :foreground "black"))
+    (t (:background "gray")))
+  "Face for marking a breakpoint definition."
+  :group 'distel)
+
+(defface edb-breakpoint-stale-face
+  `((((type tty) (class color))
+     (:background "yellow" :foreground "black"))
+    (((type tty) (class mono))
+     (:inverse-video t))
+    (((class color) (background dark))
+     (:background "purple4"))
+    (((class color) (background light))
+     (:background "medium purple" :foreground "black"))
+    (t (:background "dark gray")))
+  "Face for marking a stale breakpoint definition."
+  :group 'distel)
+
+;; ----------------------------------------------------------------------
+;; Integration with erlang-extended-mode buffers.
+
+(make-variable-buffer-local
+ (defvar edb-module-interpreted nil
+   "Non-nil means that the buffer's Erlang module is interpreted.
+This variable is meaningful in erlang-extended-mode buffers.
+The interpreted status refers to the node currently being monitored by
+edb."))
+
+(defun edb-setup-source-buffer ()
+  (make-local-variable 'kill-buffer-hook)
+  (add-hook 'kill-buffer-hook 'edb-delete-buffer-breakpoints)
+  (make-local-variable 'after-change-functions)
+  (add-to-list 'after-change-functions 'edb-make-breakpoints-stale)
+  (edb-update-interpreted-status)
+  (when edb-module-interpreted
+    (edb-create-buffer-breakpoints (edb-module))))
+
+(add-hook 'erlang-extended-mode-hook
+	  'edb-setup-source-buffer)
+
+;; ----------------------------------------------------------------------
+;; EDB minor mode for erlang-mode source files
+
+(defun edb-toggle-interpret (node module file)
+  "Toggle debug-interpreting of the current buffer's module."
+  (interactive (list (erl-target-node)
+		     (edb-module)
+		     buffer-file-name))
+  (when (edb-ensure-monitoring node)
+    (erl-spawn
+      (erl-set-name "EDB RPC to toggle interpretation of %S on %S"
+		    module node)
+      (erl-send-rpc node 'distel 'debug_toggle (list module file))
+      (erl-receive (module)
+	  ((['rex 'interpreted]
+	    (message "Interpreting: %S" module))
+	   (['rex 'uninterpreted]
+	    (message "Stopped interpreting: %S" module))
+	   (['rex ['badrpc reason]]
+	    (message "Failed to interpret-toggle: %S" reason)))))))
+
+(defun edb-module ()
+  (if (erlang-get-module)
+      (intern (erlang-get-module))
+    (error "Can't determine module for current buffer")))
+
+(defun edb-toggle-breakpoint (node module line)
+  "Toggle a breakpoint on the current line."
+  (interactive (list (erl-target-node)
+		     (edb-module)
+		     (edb-line-number)))
+  (unless (edb-module-interpreted-p module)
+    (error "Module is not interpreted, can't set breakpoints."))
+  (if edb-buffer-breakpoints-stale
+      (edb-toggle-stale-breakpoint module line)
+    (edb-toggle-real-breakpoint node module line)))
+
+(defun edb-toggle-stale-breakpoint (module line)
+  (let ((overlay (edb-first (lambda (ov) (overlay-get ov 'edb-breakpoint))
+			    (overlays-in (line-beginning-position)
+					 (1+ (line-end-position))))))
+    (if overlay
+	(delete-overlay overlay)
+      (edb-create-breakpoint module line))))
+
+(defun edb-toggle-real-breakpoint (node module line)
+  (when (edb-ensure-monitoring node)
+    (erl-spawn
+      (erl-set-name "EDB RPC to toggle of breakpoint %S:%S on %S"
+		    module line node)
+      (erl-send-rpc node 'distel 'break_toggle (list module line))
+      (erl-receive (module line)
+	  ((['rex 'enabled]
+	    (message "Enabled breakpoint at %S:%S" module line))
+	   (['rex 'disabled]
+	    (message "Disabled breakpoint at %S:%S" module line)))))))
+
+(defun edb-module-interpreted-p (module)
+  (assoc module edb-interpreted-modules))
+
+(defun edb-line-number ()
+  "Current line number."
+  ;; Taken from `count-lines' in gud.el
+  (save-restriction
+    (widen)
+    (+ (count-lines 1 (point))
+       (if (bolp) 1 0))))
+
+(defun edb-save-dbg-state (node)
+  "Save debugger state (modules to interpret and breakpoints).
+Use edb-restore-dbg-state to restore the state to the erlang node."
+  (interactive (list (erl-target-node)))
+  (let ((do-save nil))
+    (when (or (null edb-saved-interpreted-modules)
+	      (y-or-n-p "You already have a saved debugger state, continue? "))
+      (setq edb-saved-interpreted-modules edb-interpreted-modules)
+      (edb-save-breakpoints node)
+      (message "Debugger state saved."))))
+
+(defun edb-restore-dbg-state (node)
+  "Restore debugger state (modules to interpret and breakpoints)."
+  (interactive (list (erl-target-node)))
+  (if edb-saved-interpreted-modules
+      (when (edb-ensure-monitoring node)
+	(erl-spawn
+	  (erl-set-name "EDB RPC to restore debugger state on %S" node)
+	  (erl-send-rpc node 'distel 'debug_add
+			(list edb-saved-interpreted-modules))
+	  (erl-receive (node)
+	      ((['rex 'ok]
+		(when (edb-restore-breakpoints
+		       node
+		       (lambda ()
+			 (message "Debugger state restored.")))))))))
+    (message "No saved debugger state, aborting.")))
+
+
+;; ----------------------------------------------------------------------
+;; Monitor process
+
+(defvar edb-monitor-buffer nil
+  "Monitor process/viewer buffer.")
+
+(defvar edb-monitor-node nil
+  "Node we are debug-monitoring.")
+
+(defvar edb-monitor-mode-map nil
+  "Keymap for Erlang debug monitor mode.")
+
+(defvar edb-interpreted-modules '()
+  "Set of (module filename) being interpreted on the currently monitored node.")
+
+(defvar edb-saved-interpreted-modules '()
+  "Set of (module filename) to interpret if edb-restore-dbg-state is called.")
+
+(unless edb-monitor-mode-map
+  (setq edb-monitor-mode-map (make-sparse-keymap))
+  (define-key edb-monitor-mode-map [return] 'edb-attach-command)
+  (define-key edb-monitor-mode-map [(control m)] 'edb-attach-command)
+  (define-key edb-monitor-mode-map [?a] 'edb-attach-command)
+  (define-key edb-monitor-mode-map [?q] 'erl-bury-viewer)
+  (define-key edb-monitor-mode-map [?k] 'erl-quit-viewer))
+
+(defvar edb-processes nil
+  "EWOC of processes running interpreted code.")
+
+(defstruct (edb-process
+	    (:constructor nil)
+	    (:constructor make-edb-process (pid mfa status info)))
+  pid mfa status info)
+
+(defun edb-monitor-mode ()
+  "Major mode for viewing debug'able processes.
+
+Available commands:
+\\[edb-attach-command]	- Attach to the process at point.
+\\[erl-bury-viewer]	- Hide the monitor window.
+\\[erl-quit-viewer]	- Quit monitor."
+  (interactive)
+  (kill-all-local-variables)
+  (setq buffer-read-only t)
+  (setq erl-old-window-configuration (current-window-configuration))
+  (use-local-map edb-monitor-mode-map)
+  (setq mode-name "EDB Monitor")
+  (setq major-mode 'edb-monitor-mode))
+
+(defun edb-monitor-insert-process (p)
+  (let ((buffer-read-only nil)
+	(text (edb-monitor-format (erl-pid-to-string (edb-process-pid p))
+				  (edb-process-mfa p)
+				  (edb-process-status p)
+				  (edb-process-info p))))
+    (put-text-property 0 (length text) 'erl-pid (edb-process-pid p) text)
+    (insert text)))
+
+(defun edb-monitor-format (pid mfa status info)
+  (format "%s %s %s %s"
+	  (padcut pid 12)
+	  (padcut mfa 21)
+	  (padcut status 9)
+	  (cut info 21)))
+
+(defun padcut (s w)
+  (let ((len (length s)))
+    (cond ((= len w) s)
+	  ((< len w) (concat s (make-string (- w len) ? )))
+	  ((> len w) (substring s 0 w)))))
+
+(defun cut (s w)
+  (if (> (length s) w)
+      (substring s 0 w)
+    s))
+
+(defun edb-monitor-header ()
+  (edb-monitor-format "PID" "Initial Call" "Status" "Info"))
+
+(defun edb-monitor (node)
+  (interactive (list (erl-target-node)))
+  (when (edb-ensure-monitoring node)
+    (unless (get-buffer-window edb-monitor-buffer)
+      ;; Update the restorable window configuration
+      (with-current-buffer edb-monitor-buffer
+	(setq erl-old-window-configuration
+	      (current-window-configuration))))
+    (pop-to-buffer edb-monitor-buffer)
+    (condition-case nil
+        (progn 
+          (search-forward "break")
+          (move-beginning-of-line))
+      (error nil))))
+    ;;    (goto-char (point-max))
+    ;;   (forward-line -2)))
+
+(defun edb-ensure-monitoring (node)
+  "Make sure the debug monitor is watching the node.
+Returns NIL if this cannot be ensured."
+  (if (edb-monitor-node-change-p node)
+      (when (y-or-n-p (format "Attach debugger to %S instead of %S? "
+			      node edb-monitor-node))
+	;; Kill existing edb then start again
+	(kill-buffer edb-monitor-buffer)
+	(edb-start-monitor node))
+    (if (edb-monitor-live-p)
+	t
+      (edb-start-monitor node))))
+
+(defun edb-monitor-node-change-p (node)
+  "Do we have to detach/reattach to debug on NODE?"
+  (and (edb-monitor-live-p)
+       (not (equal node edb-monitor-node))))
+
+(defun edb-monitor-live-p ()
+  "Are we actively debug-monitoring a node?"
+  (and edb-monitor-buffer
+       (buffer-live-p edb-monitor-buffer)))
+
+(defun edb-monitor-buffer-name (node)
+  (format "*edb %S*" node))
+
+(defun edb-start-monitor (node)
+  "Start debug-monitoring NODE."
+  (erl-spawn
+    (erl-set-name "EDB Monitor on %S" node)
+    (setq edb-monitor-node node)
+    (setq edb-monitor-buffer (current-buffer))
+    (rename-buffer (edb-monitor-buffer-name node))
+    (edb-monitor-mode)
+    (make-local-variable 'kill-buffer-hook)
+    (add-hook 'kill-buffer-hook 'edb-monitor-cleanup)
+    (erl-send-rpc node 'distel 'debug_subscribe (list erl-self))
+    (erl-receive (node)
+	((['rex [interpreted breaks snapshot]]
+	  (setq edb-interpreted-modules interpreted)
+	  (edb-init-breakpoints breaks)
+	  (edb-update-source-buffers)
+	  (setq edb-processes
+		(ewoc-create 'edb-monitor-insert-process
+			     (edb-monitor-header)))
+	  (mapc (lambda (item)
+		  (mlet [pid mfa status info] item
+		    (ewoc-enter-last edb-processes
+				     (make-edb-process pid
+						       mfa
+						       status
+						       info))))
+		snapshot)
+	  (&edb-monitor-loop))))))
+
+(defun &edb-monitor-loop ()
+  "Monitor process main loop.
+Tracks events and state changes from the Erlang node."
+  (erl-receive ()
+      ((['int ['new_status pid status info]]
+	 (let ((proc (edb-monitor-lookup pid)))
+	   (if (null proc)
+	       (message "Unknown process: %s" (erl-pid-to-string pid))
+	     (setf (edb-process-status proc) (symbol-name status))
+	     (setf (edb-process-info proc) info)
+	     (when (and edb-popup-monitor-on-event
+			(edb-interesting-event-p pid status info))
+	       (display-buffer (current-buffer))))))
+       ;;
+       (['int ['new_process (pid mfa status info)]]
+	 (ewoc-enter-last edb-processes
+			  (make-edb-process pid
+					    mfa
+					    (symbol-name status)
+					    info)))
+       ;;
+       (['int ['interpret mod file]]
+	(push (list mod file) edb-interpreted-modules)
+	(edb-update-source-buffers mod))
+       ;;
+       (['int ['no_interpret mod]]
+	(setq edb-interpreted-modules
+	      (assq-delete-all mod edb-interpreted-modules))
+	(edb-update-source-buffers mod))
+       ;;
+       (['int ['no_break mod]]
+	(edb-delete-breakpoints mod))
+       ;;
+       (['int ['new_break [[mod line] _info]]]
+	(edb-create-breakpoint mod line))
+       ;;
+       (['int ['delete_break [mod line]]]
+	(edb-delete-breakpoint mod line)))
+    (ewoc-refresh edb-processes)    
+    (&edb-monitor-loop)))
+
+(defun edb-get-buffer (mod)
+  (edb-get-buffer2 mod (buffer-list)))
+
+(defun edb-get-buffer2 (mod bufl)
+  (if (null bufl) nil
+    (with-current-buffer (car bufl)
+      (if (and erlang-extended-mode
+	       (eq (edb-source-file-module-name) mod))
+	  (car bufl)
+	(edb-get-buffer2 mod (cdr bufl))))))
+
+
+(defun edb-interesting-event-p (pid status info)
+  (or (and (eq status 'exit)
+	   (edb-attached-p pid))
+      (and (eq status 'break)
+	   (not (edb-attached-p pid)))))
+
+(defun edb-update-interpreted-status ()
+  "Update `edb-module-interpreted' for current buffer."
+  (when erlang-extended-mode
+    (let ((mod (edb-source-file-module-name)))
+      (if (and mod (assq mod edb-interpreted-modules))
+	  (setq edb-module-interpreted t)
+	(setq edb-module-interpreted nil)
+	;; the erlang debugger automatically removes breakpoints when a
+	;; module becomes uninterpreted, so we match it here
+	(edb-delete-breakpoints (edb-source-file-module-name))))
+    (force-mode-line-update)))
+
+(defun edb-update-source-buffers (&optional mod)
+  "Update the debugging state of all Erlang buffers.
+When MOD is given, only update those visiting that module."
+  (mapc (lambda (buf)
+	  (with-current-buffer buf
+	    (when (and erlang-extended-mode
+		       (or (null mod)
+			   (eq (edb-source-file-module-name) mod)))
+	      (edb-update-interpreted-status))))
+	(buffer-list)))
+
+(defun edb-source-file-module-name ()
+  "Return the Erlang module of the current buffer as a symbol, or NIL."
+  (let ((name (erlang-get-module)))
+    (if name (intern name) nil)))
+
+(defun edb-monitor-lookup (pid)
+  (car (ewoc-collect edb-processes
+		     (lambda (p) (equal (edb-process-pid p) pid)))))
+
+(defun edb-monitor-cleanup ()
+  "Cleanup state after the edb process exits."
+  (setq edb-interpreted-modules '())
+  (edb-delete-all-breakpoints)
+  (edb-update-source-buffers)
+  (setq edb-monitor-node nil))
+
+;; ----------------------------------------------------------------------
+;; Attach process
+
+(make-variable-buffer-local
+ (defvar edb-pid nil
+   "Pid of attached process."))
+
+(make-variable-buffer-local
+ (defvar edb-node nil
+   "Node of attached process."))
+
+(make-variable-buffer-local
+ (defvar edb-module nil
+   "Current module source code in attach buffer."))
+
+(make-variable-buffer-local 
+ (defvar edb-variables-buffer nil
+   "Buffer showing variable bindings of attached process."))
+
+(make-variable-buffer-local 
+ (defvar edb-attach-buffer nil
+   "True if buffer is attach buffer."))
+
+(defvar edb-attach-with-new-frame nil
+  "When true, attaching to a process opens a new frame.")
+
+;; Attach setup
+
+(defun edb-attach-command ()
+  (interactive)
+  (let ((pid (get-text-property (point) 'erl-pid)))
+    (if pid
+	(progn (when edb-attach-with-new-frame 
+		 (select-frame (make-frame)))
+	       (edb-attach pid))
+      (error "No process at point."))))
+
+(defun edb-attach (pid)
+  (let ((old-window-config (current-window-configuration)))
+    (delete-other-windows)
+    (switch-to-buffer (edb-attach-buffer pid))
+    (setq erl-old-window-configuration old-window-config)))
+
+(defun edb-attach-buffer (pid)
+  (let ((bufname (edb-attach-buffer-name pid)))
+    (or (get-buffer bufname)
+	(edb-new-attach-buffer pid))))
+
+(defun edb-new-attach-buffer (pid)
+  "Start a new attach process and returns its buffer."
+  (erl-pid->buffer
+   (erl-spawn
+     (erl-set-name "EDB Attach to process %S on %S"
+		   (erl-pid-id pid)
+		   (erl-pid-node pid))
+     (rename-buffer (edb-attach-buffer-name pid))
+     ;; We must inhibit the erlang-new-file-hook, otherwise we trigger
+     ;; it by entering erlang-mode in an empty buffer
+     (let ((erlang-new-file-hook nil))
+       (erlang-mode))
+     (erlang-extended-mode t)
+     (edb-attach-mode t)
+     (setq edb-attach-buffer t)
+     (message "Entered debugger. Press 'h' for help.")
+     (setq buffer-read-only t)
+     (erl-send-rpc (erl-pid-node pid)
+		   'distel 'debug_attach (list erl-self pid))
+     (erl-receive ()
+	 ((['rex pid]
+	   (assert (erl-pid-p pid))
+	   (setq edb-pid pid)
+	   (setq edb-node (erl-pid-node pid))
+	   (save-excursion (edb-make-variables-window))))
+       (&edb-attach-loop)))))
+
+;; Variables listing window
+
+(defun edb-make-variables-window ()
+  "Make a window and buffer for viewing variable bindings.
+The *Variables* buffer is killed with the current buffer."
+  (split-window-vertically (edb-variables-window-height))
+  (let ((vars-buf (edb-make-variables-buffer)))
+    (setq edb-variables-buffer vars-buf)
+    (make-local-variable 'kill-buffer-hook)
+    (add-hook 'kill-buffer-hook
+	      (lambda () (kill-buffer edb-variables-buffer)))
+    (other-window 1)
+    (switch-to-buffer vars-buf)
+    (other-window -1)))
+
+(defun edb-variables-window-height ()
+  (- (min (/ (window-height) 2) 12)))
+
+(defun edb-make-variables-buffer ()
+  "Create the edb variable list buffer."
+  (let ((meta-pid edb-pid))
+    (with-current-buffer (generate-new-buffer "*Variables*")
+      (edb-variables-mode)
+      (setq edb-pid meta-pid)
+      (current-buffer))))
+
+(defun edb-variables-mode ()
+  (kill-all-local-variables)
+  (setq major-mode 'edb-variables)
+  (setq mode-name "EDB Variables")
+  (setq buffer-read-only t)
+  (use-local-map edb-variables-mode-map))
+
+(defvar edb-variables-mode-map nil
+  "Keymap for EDB variables viewing.")
+
+(when (null edb-variables-mode-map)
+  (setq edb-variables-mode-map (make-sparse-keymap))
+  (define-key edb-variables-mode-map [?m]          'edb-show-variable)
+  (define-key edb-variables-mode-map [(control m)] 'edb-show-variable))
+
+(defun edb-show-variable ()
+  "Pop a window showing the full value of the variable at point."
+  (interactive)
+  (let ((var (get-text-property (point) 'edb-variable-name)))
+    (if (null var)
+	(message "No variable at point")
+      (edb-attach-meta-cmd `[get_binding ,var]))))
+
+;; Attach process states
+
+(defun &edb-attach-loop ()
+  "Attached process loop."
+  (erl-receive ()
+      ((['location mod line pos max]
+ 	(let ((msg (format "Location: %S:%S (Stack pos: %S/%S)"
+			   mod line pos max)))
+ 	  (setq header-line-format msg))
+	(&edb-attach-goto-source mod line))
+       (['status status]
+	(unless (memq status '(running idle))
+	  (message "Unrecognised status: %S" status))
+	(setq header-line-format (format "Status: %S" status))
+	(setq overlay-arrow-position nil)
+	(&edb-attach-loop))
+       (['variables vars]
+	;; {variables, [{Name, String}]}
+	(when (buffer-live-p edb-variables-buffer)
+	  (with-current-buffer edb-variables-buffer
+	    (let ((buffer-read-only nil))
+	      (erase-buffer)
+	      (mapc (lambda (b)
+		      (let ((name   (tuple-elt b 1))
+			    (string (tuple-elt b 2)))
+			(put-text-property 0 (length string)
+					   'edb-variable-name name
+					   string)
+			(insert string)))
+		    vars))))
+	(&edb-attach-loop))
+       (['message msg]
+	(message msg)
+	(&edb-attach-loop))
+       (['show_variable value]
+	(save-excursion (display-message-or-view value "*Variable Value*"))
+	(&edb-attach-loop))
+       (other
+	(message "Other: %S" other)
+	(&edb-attach-loop)))))
+
+(defun &edb-attach-goto-source (module line)
+  "Display MODULE:LINE in the attach buffer and reenter attach loop."
+  (if (eq edb-module module)
+      (progn (edb-attach-goto-line line)
+	     (&edb-attach-loop))
+    (&edb-attach-find-source module line)))
+
+(defun &edb-attach-find-source (module line)
+  "Load the source code for MODULE into current buffer at LINE.
+Once loaded, reenters the attach loop."
+  (erl-send-rpc edb-node 'distel 'find_source (list module))
+  (erl-receive (module line)
+      ((['rex ['ok path]]
+	(if (file-regular-p path)
+	    (progn (setq edb-module module)
+		   (let ((buffer-read-only nil))
+		     (erase-buffer)
+		     (insert-file-contents path))
+		   (edb-delete-buffer-breakpoints)
+		   (edb-create-buffer-breakpoints module)
+		   (edb-attach-goto-line line))
+	  (message "No such file: %s" path))))
+    (&edb-attach-loop)))
+
+(defun edb-attach-goto-line (line)
+  (goto-line line)
+  (setq overlay-arrow-string "=>")
+  (setq overlay-arrow-position (copy-marker (point))))
+
+(defun edb-attach-buffer-name (pid)
+  (format "*edbproc %s on %S*"
+	  (erl-pid-to-string pid)
+	  (erl-pid-node pid)))
+
+(defun edb-attached-p (pid)
+  "Non-nil when we have an attach buffer viewing PID."
+  (buffer-live-p (get-buffer (edb-attach-buffer-name pid))))
+
+;; ----------------------------------------------------------------------
+;; Attach minor mode and commands
+
+(define-minor-mode edb-attach-mode
+  "Minor mode for debugging an Erlang process.
+
+Available commands:
+\\<edb-attach-mode-map>
+\\[edb-attach-help]	- Popup this help text.
+\\[erl-quit-viewer]	- Quit the viewer (doesn't kill the process)
+\\[edb-attach-step]	- Step (into expression)
+\\[edb-attach-next]	- Next (over expression)
+\\[edb-attach-up]	- Up to the next stack frame
+\\[edb-attach-down]	- Down to the next stack frame
+\\[edb-attach-continue]	- Continue (until breakpoint)
+\\[edb-toggle-breakpoint]	- Toggle a breakpoint on the current line."
+  nil
+  " (attached)"
+  '(([? ] . edb-attach-step)
+    ([?n] . edb-attach-next)
+    ([?c] . edb-attach-continue)
+    ([?u] . edb-attach-up)
+    ([?d] . edb-attach-down)
+    ([?q] . erl-quit-viewer)
+    ([?h] . edb-attach-help)
+    ([?b] . edb-toggle-breakpoint)))
+
+(defun edb-attach-help ()
+  (interactive)
+  (describe-function 'edb-attach-mode))
+
+(defun edb-attach-step ()
+  (interactive)
+  (edb-attach-meta-cmd 'step))
+(defun edb-attach-next ()
+  (interactive)
+  (edb-attach-meta-cmd 'next))
+(defun edb-attach-continue ()
+  (interactive)
+  (edb-attach-meta-cmd 'continue))
+(defun edb-attach-up ()
+  (interactive)
+  (edb-attach-meta-cmd 'up))
+(defun edb-attach-down ()
+  (interactive)
+  (edb-attach-meta-cmd 'down))
+
+(defun edb-attach-meta-cmd (cmd)
+  (erl-send edb-pid `[emacs meta ,cmd]))
+
+;; ----------------------------------------------------------------------
+;; Breakpoints
+
+(defvar edb-breakpoints '()
+  "List of all breakpoints on the currently monitored node.")
+
+(defvar edb-saved-breakpoints '()
+  "List of breakpoints to set if edb-restore-dbg-state is called.")
+
+(make-variable-buffer-local 
+ (defvar edb-buffer-breakpoints nil
+   "List of active buffer breakpoints."))
+
+(make-variable-buffer-local 
+ (defvar edb-buffer-breakpoints-stale nil
+   "Nil if the breakpoints in the buffer are stale (out of synch)."))
+
+;; breakpoints
+(defun make-bp (mod line) (list mod line))
+(defun bp-mod (bp) (car bp))
+(defun bp-line (bp) (cadr bp))
+
+;; buffer breakpoints
+(defun make-bbp (mod line ov) (list mod line ov))
+(defun bbp-mod (bbp) (car bbp))
+(defun bbp-line (bbp) (cadr bbp))
+(defun bbp-ov (bbp) (caddr bbp))
+
+(defun edb-init-breakpoints (breaks)
+  (setq edb-breakpoints
+	(mapcar (lambda (pos)
+		  (let ((mod (aref pos 0))
+			(line (aref pos 1)))
+		    (make-bp mod line)))
+		breaks))
+  (mapc
+   (lambda (buf)
+     (with-current-buffer buf
+       (when erlang-extended-mode
+	 (edb-create-buffer-breakpoints (edb-source-file-module-name)))))
+   (buffer-list)))
+  
+
+(defun edb-create-breakpoint (mod line)
+  "Updates all internal structures in all buffers with new breakpoint."
+  (push (make-bp mod line) edb-breakpoints)
+  (mapc
+   (lambda (buf)
+     (with-current-buffer buf
+       (if (and erlang-extended-mode
+		(eq (edb-source-file-module-name) mod))
+	   (let ((bbp (make-bbp mod line (edb-make-breakpoint-overlay line))))
+	     (push bbp edb-buffer-breakpoints)))))
+   (buffer-list)))
+
+(defun edb-delete-all-breakpoints ()
+  "Updates all internal structures in all buffers."
+  (edb-del-breakpoints
+   (lambda (bp) t)
+   (lambda (bbp) t)))
+
+(defun edb-delete-breakpoints (mod)
+  "Updates all internal structures in all buffers."
+  (edb-del-breakpoints
+   (lambda (bp) (eq (bp-mod bp) mod))
+   (lambda (bbp) (eq (bbp-mod bbp) mod))
+   mod))
+
+(defun edb-delete-breakpoint (mod line)
+  "Updates all internal structures in all buffers."
+  (edb-del-breakpoints
+   (lambda (bp) (and (eq (bp-mod bp) mod)
+		     (eq (bp-line bp) line)))
+   (lambda (bbp) (and (eq (bbp-mod bbp) mod)
+		      (eq (bbp-line bbp) line)))
+   mod))
+
+(defun edb-create-buffer-breakpoints (mod)
+  "Creates buffer breakpoints in the current buffer."
+  (when edb-buffer-breakpoints
+    ;; remove old/stale breakpoints
+    (edb-delete-buffer-breakpoints))
+  (setq edb-buffer-breakpoints (edb-mk-bbps mod)))
+
+(defun edb-delete-buffer-breakpoints ()
+  "Deletes all buffer breakpoints in the current buffer."
+  (setq edb-buffer-breakpoints 
+	(edb-del-bbps edb-buffer-breakpoints (lambda (bbp) t))))
+
+(defun edb-del-breakpoints (bp-f bbp-f &optional mod)
+  "Updates all internal structures in all buffers."
+  (setq edb-breakpoints (erl-remove-if bp-f edb-breakpoints))
+  (mapc
+   (lambda (buf)
+     (with-current-buffer buf
+       (if (and erlang-extended-mode
+		(or (not mod)
+		    (eq (edb-source-file-module-name) mod)))
+	   (setq edb-buffer-breakpoints
+		 (edb-del-bbps edb-buffer-breakpoints bbp-f)))))
+   (buffer-list)))
+
+(defun edb-synch-breakpoints (node module)
+  "Synchronizes the breakpoints in the current buffer to erlang.
+I.e. deletes all old breakpoints, and re-applies them at the current line."
+  (interactive (list (erl-target-node)
+		     (edb-module)))
+  (when (edb-ensure-monitoring node)
+    (let ((id (lambda (r) r)))
+      (mapc (lambda (new-bbp)
+	      (let ((bbp (car new-bbp))
+		    (new-line (cdr new-bbp)))
+		(erl-rpc id nil node 'distel 'break_delete
+			 (list (bbp-mod bbp) (bbp-line bbp)))
+		(erl-rpc id nil node 'distel 'break_add
+			 (list module new-line))))
+	    (edb-new-bbps))
+      (setq edb-buffer-breakpoints-stale nil))))
+
+(defun edb-make-breakpoints-stale (begin end length)
+  "Make breakpoints in the current buffer stale.
+Has no effect if the buffer's module is not interpreted, or the
+breakpoints are already marked as stale."
+  (when (and (not edb-attach-buffer)
+	     (not edb-buffer-breakpoints-stale)
+	     edb-module-interpreted)
+    (mapc (lambda (bbp)
+	    (let ((ov (bbp-ov bbp)))
+	      (overlay-put ov 'face 'edb-breakpoint-stale-face)))
+	  edb-buffer-breakpoints)
+    (setq edb-buffer-breakpoints-stale t)))
+
+(defun edb-save-breakpoints (node)
+  (let ((modules '()))
+    (setq edb-saved-breakpoints '())
+    (mapc
+     (lambda (buf)
+       (with-current-buffer buf
+	 (if erlang-extended-mode
+	     (let ((cur-mod (edb-source-file-module-name)))
+	       (unless (member cur-mod modules)
+		 (let ((new-lines (mapcar (lambda (new-bbp) (cdr new-bbp))
+					  (edb-new-bbps))))
+		   (push cur-mod modules)
+		   (push (list cur-mod new-lines) edb-saved-breakpoints)))))))
+     (buffer-list))
+    (mapc (lambda (bp)
+	    (unless (member (bp-mod bp) modules)
+	      (push (list (bp-mod bp) (list (bp-line bp)))
+		    edb-saved-breakpoints)))
+	  edb-breakpoints)))
+
+(defun edb-restore-breakpoints (node cont)
+  (erl-send-rpc node 'distel 'break_restore (list edb-saved-breakpoints))
+  (erl-receive (cont)
+      ((['rex 'ok]
+	(funcall cont))
+       (['rex ['badrpc reason]]
+	(message "Failed to restore breakpoints: %S" reason)))))
+
+(defun edb-new-bbps ()
+  (mapcar (lambda (bbp)
+	    (let* ((new-pos (overlay-start (bbp-ov bbp)))
+		   (new-line (+ (count-lines (point-min) new-pos) 1)))
+	      (cons bbp new-line)))
+	  edb-buffer-breakpoints))
+
+(defun edb-mk-bbps (mod)
+  (zf
+   (lambda (bp)
+     (let ((bmod (bp-mod bp))
+	   (line (bp-line bp)))
+       (if (eq bmod mod)
+	   (let ((ov (edb-make-breakpoint-overlay line)))
+	     (make-bbp bmod line ov))
+	 nil)))
+   edb-breakpoints))
+
+(defun edb-del-bbps (list pred)
+  (zf
+   (lambda (bbp)
+     (cond ((funcall pred bbp)
+	    (delete-overlay (bbp-ov bbp))
+	    nil)
+	   (t bbp)))
+   list))
+
+(defun edb-make-breakpoint-overlay (line)
+  "Creats an overlay at line"
+  (save-excursion
+    (goto-line line)
+    (let ((ov (make-overlay (line-beginning-position)
+			    (line-beginning-position 2)
+			    (current-buffer)
+			    t
+			    nil)))
+      (overlay-put ov 'edb-breakpoint t)
+      (if edb-buffer-breakpoints-stale
+	  (overlay-put ov 'face 'edb-breakpoint-stale-face)
+	(overlay-put ov 'face 'edb-breakpoint-face))
+      ov)))
+    
+(defun zf (f l)
+  (let ((res nil))
+    (dolist (x l)
+      (let ((r (funcall f x)))
+	(if r (push r res))))
+    res))
+
+(defun edb-first (pred list)
+  "Return the first element of LIST that satisfies PRED."
+  (loop for x in list
+	when (funcall pred x) return x))
+
+(provide 'edb)

--- a/elisp/erl.el
+++ b/elisp/erl.el
@@ -642,7 +642,7 @@ during the next `erl-schedule'."
                                          (display-buffer (current-buffer)))))
                   (goto-char (point-max))
                   (insert s))))
-	    (error (message "Error in group leader: %S" err))))))
+          (error (message "Error in group leader: %S" err))))))
     (&erl-group-leader-loop)))
 
 (when (null erl-group-leader)

--- a/elisp/patmatch.el
+++ b/elisp/patmatch.el
@@ -208,5 +208,25 @@ EXPECTED is either 'fail or a list of bindings (in any order)."
       (error "Patmatch: %S %S => %S, expected %S"
 	     pattern object actual expected))))
 
+(defun pmatch-test ()
+  "Test the pattern matcher."
+  (interactive)
+  (pmatch-expect t t ())
+  (pmatch-expect '(t nil 1) '(t nil 1) ())
+  (let ((foo 'foo))
+    (pmatch-expect '(FOO ,foo 'foo [FOO]) '(foo foo foo [foo])
+		   '((FOO . foo))))
+  (pmatch-expect 1 2 'fail)
+  (pmatch-expect '(x x) '(1 2) 'fail)
+  (pmatch-expect '_ '(1 2) 'nil)
+  (assert (equal 'yes
+		 (mcase '(call 42 lists length ((1 2 3)))
+		   (t 'no)
+		   (1 'no)
+		   ((call Ref 'lists 'length (_))
+		    'yes)
+		   (_ 'no))))
+  (message "Smooth sailing"))
+
 (provide 'patmatch)
 

--- a/elisp/wrangler.el
+++ b/elisp/wrangler.el
@@ -1,3 +1,4 @@
+;;; wrangler.el --- Top level of wrangler package, loads all subparts
 
 ;; Prerequisites
 
@@ -5,11 +6,14 @@
 (require 'wrangler-clearcase-hooks)
 (require 'vc)
 (require 'erlang)
+(require 'distel)
 (require 'read-char-spec)
 
 (if (eq (substring emacs-version 0 4) "22.2")
     (require 'ediff-init1)
   (require 'ediff-init))
+
+(distel-setup)
 
 (provide 'wrangler)
 

--- a/src/distel.erl
+++ b/src/distel.erl
@@ -1,3 +1,4 @@
+%% -*- erlang-indent-level: 4 -*-
 %%%-------------------------------------------------------------------
 %%% File    : distel.erl
 %%% Author  : Luke Gorrie <luke@bluetail.com>
@@ -13,34 +14,38 @@
 
 -include_lib("kernel/include/file.hrl").
 
+-import(lists, [any/2
+                , append/1
+                , duplicate/2
+                , filter/2
+                , flatten/1
+                , foldl/3
+                , foreach/2
+                , keysearch/3
+                , map/2
+                , member/2
+                , prefix/2
+                , reverse/1
+                , sort/1
+                , usort/1
+               ]).
 
--import(lists, [flatten/1, member/2, sort/1, map/2, foldl/3, foreach/2]).
--import(filename, [dirname/1,join/1,basename/2]).
-
--export([rpc_entry/3, eval_expression/1, find_source/1,
-         process_list/0, process_summary/1,
-         process_summary_and_trace/2, fprof/3, fprof_analyse/1,
-         debug_toggle/2, debug_subscribe/1, debug_add/1,
-         break_toggle/2, break_delete/2, break_add/2, break_restore/1,
-         modules/1, functions/2, who_calls/3,
-         rebuild_completions/0, rebuild_call_graph/0,
-         free_vars/1, free_vars/2,
-         apropos/1, apropos/2, describe/3, describe/4]).
-
--export([reload_module/2,reload_modules/0]).
-
--export([gl_proxy/1, tracer_init/2, null_gl/0]).
+-import(filename, [dirname/1
+                   , join/1
+                   , basename/2]).
 
 -compile(export_all).
 
+fmt(F, A) -> to_bin(io_lib:fwrite(F,A)).
+
 to_bin(X) -> list_to_binary(to_list(X)).
 to_atom(X) -> list_to_atom(to_list(X)).
-     
+
 to_list(X) when is_binary(X) -> binary_to_list(X);
 to_list(X) when is_integer(X)-> integer_to_list(X);
 to_list(X) when is_float(X)  -> float_to_list(X);
 to_list(X) when is_atom(X)   -> atom_to_list(X);
-to_list(X) when is_list(X)   -> X.		%Assumed to be a string
+to_list(X) when is_list(X)   -> X.              %Assumed to be a string
 
 %% ----------------------------------------------------------------------
 %% RPC entry point, adapting the group_leader protocol.
@@ -59,7 +64,7 @@ rpc_entry(M, F, A) ->
     apply(M,F,A).
 
 gl_name(Pid) ->
-    to_atom(flatten(io_lib:format("distel_gl_for_~p", [Pid]))).
+    to_atom(fmt("distel_gl_for_~p", [Pid])).
 
 gl_proxy(GL) ->
     receive
@@ -67,6 +72,9 @@ gl_proxy(GL) ->
             GL ! {put_chars, C},
             From ! {io_reply, ReplyAs, ok};
         {io_request, From, ReplyAs, {put_chars, M, F, A}} ->
+            GL ! {put_chars, flatten(apply(M, F, A))},
+            From ! {io_reply, ReplyAs, ok};
+        {io_request, From, ReplyAs, {put_chars,unicode,M,F,A}} ->
             GL ! {put_chars, flatten(apply(M, F, A))},
             From ! {io_reply, ReplyAs, ok};
         {io_request, From, ReplyAs, {get_until, _, _, _}} ->
@@ -79,48 +87,48 @@ gl_proxy(GL) ->
 %%% reload all modules that are out of date
 %%% compare the compile time of the loaded beam and the beam on disk
 reload_modules() ->
-    T = fun(L) -> [X || X <- L, element(1,X)==time] end,
+    T = fun(L) -> [X || X <- L, element(1,X) =:= time] end,
     Tm = fun(M) -> T(M:module_info(compile)) end,
     Tf = fun(F) -> {ok,{_,[{_,I}]}}=beam_lib:chunks(F,[compile_info]),T(I) end,
     Load = fun(M) -> c:l(M),M end,
-    
+
     [Load(M) || {M,F} <- code:all_loaded(), is_beamfile(F), Tm(M)<Tf(F)].
 
-is_beamfile(F) -> 
+is_beamfile(F) ->
     ok == element(1,file:read_file_info(F)) andalso
-	".beam" == filename:extension(F).
+        ".beam" == filename:extension(F).
 
 %% ----------------------------------------------------------------------
-%% if c:l(Mod) doesn't work, we look for the beam file in 
-%% srcdir and srcdir/../ebin; add the first one that works to path and 
+%% if c:l(Mod) doesn't work, we look for the beam file in
+%% srcdir and srcdir/../ebin; add the first one that works to path and
 %% try c:l again.
 %% srcdir is dirname(EmacsBuffer); we check that the buffer contains Mod.erl
 %% emacs will set File = "" to indicate that we don't want to mess with path
 reload_module(Mod, File) ->
     case c:l(to_atom(Mod)) of
-	{error,R} ->
-	    case Mod == basename(File,".erl") of
-		true ->
-		    Beams = [join([dirname(File),Mod]),
-			     join([dirname(dirname(File)),ebin,Mod])],
-			case lists:filter(fun is_beam/1, Beams) of
-			    [] -> {error, R};
-			    [Beam|_] -> 
-				code:add_patha(dirname(Beam)),
-				c:l(to_atom(Mod))
-			end;
-		false ->
-		    {error,R}
-	    end;
-	R -> R
+        {error,R} ->
+            case Mod == basename(File,".erl") of
+                true ->
+                    Beams = [join([dirname(File),Mod]),
+                             join([dirname(dirname(File)),ebin,Mod])],
+                        case filter(fun is_beam/1, Beams) of
+                            [] -> {error, R};
+                            [Beam|_] ->
+                                code:add_patha(dirname(Beam)),
+                                c:l(to_atom(Mod))
+                        end;
+                false ->
+                    {error,modname_and_filename_differs}
+            end;
+        R -> R
     end.
 
 is_beam(Filename) ->
     case file:read_file_info(Filename++".beam") of
-	{ok,_} -> true;
-	{error,_} -> false
+        {ok,_} -> true;
+        {error,_} -> false
     end.
-	    
+
 %% ----------------------------------------------------------------------
 
 eval_expression(S) ->
@@ -134,7 +142,7 @@ eval_expression(S) ->
 try_evaluation(Parse) ->
     case catch erl_eval:exprs(Parse, []) of
         {value, V, _} ->
-            {ok, flatten(io_lib:format("~p", [V]))};
+            {ok, fmt("~p", [V])};
         {'EXIT', Reason} ->
             {error, Reason}
     end.
@@ -150,7 +158,7 @@ find_source(Mod) ->
       catch
         nothing -> {error,fmt("Can't find source for ~p", [BeamFName])};
         several -> {error,fmt("Several possible sources for ~p", [BeamFName])};
-	_:R -> {error,fmt("Couldnt guess source ~p ~p",[BeamFName,R])}
+        _:R -> {error,fmt("Couldnt guess source ~p ~p",[BeamFName,R])}
       end;
     error ->
       {error, fmt("Can't find module '~p' on ~p", [Mod, node()])}
@@ -163,17 +171,17 @@ guess_source_file(Mod, BeamFName) ->
   DotDot = dirname(Dir),
   try_srcs([src_from_beam(Mod),
             join([Dir, Erl]),
-            join([DotDot, src, Erl]),
-            join([DotDot, src, "*", Erl]),
-            join([DotDot, esrc, Erl]),
-            join([DotDot, erl, Erl])]).
+            join([DotDot, "src", Erl]),
+            join([DotDot, "src", "*", Erl]),
+            join([DotDot, "esrc", Erl]),
+            join([DotDot, "erl", Erl])]).
 
 try_srcs([]) -> throw(nothing);
 try_srcs(["" | T]) -> try_srcs(T);
 try_srcs([H | T]) ->
   case filelib:wildcard(H) of
-    [File] -> 
-      case filelib:is_regular(File) of 
+    [File] ->
+      case filelib:is_regular(File) of
         true -> File;
         false-> try_srcs(T)
       end;
@@ -182,10 +190,10 @@ try_srcs([H | T]) ->
   end.
 
 src_from_beam(Mod) ->
-  try 
+  try
     case Mod:module_info(compile) of
       [] -> int:file(Mod);
-      CompInfo -> {_,{_,Src}} = lists:keysearch(source,1,CompInfo), Src
+      CompInfo -> {_,{_,Src}} = keysearch(source,1,CompInfo), Src
     end
   catch _:_ -> ""
   end.
@@ -207,12 +215,12 @@ name(Pid) ->
         {registered_name, Regname} ->
             to_list(Regname);
         _ ->
-            io_lib:format("~p", [Pid])
+            to_list(fmt("~p", [Pid]))
     end.
 
 initial_call(Pid) ->
     {initial_call, {M, F, A}} = process_info(Pid, initial_call),
-    io_lib:format("~s:~s/~p", [M, F, A]).
+    to_list(fmt("~s:~s/~p", [M, F, A])).
 
 reductions(Pid) ->
     {reductions, NrReds} = process_info(Pid, reductions),
@@ -223,8 +231,7 @@ messages(Pid) ->
     to_list(length(MsgList)).
 
 iformat(A1, A2, A3, A4) ->
-    to_bin(io_lib:format("~-21s ~-33s ~12s ~8s~n",
-                                 [A1,A2,A3,A4])).
+    fmt("~-21s ~-33s ~12s ~8s~n",[A1,A2,A3,A4]).
 
 %% ----------------------------------------------------------------------
 %% Individual process summary and tracing.
@@ -247,7 +254,7 @@ process_info_item(Pid, Item) ->
 
 %% Returns: Summary : binary()
 process_summary(Pid) ->
-    Text = [io_lib:format("~-20w: ~w~n", [Key, Value])
+    Text = [fmt("~-20w: ~w~n", [Key, Value])
             || {Key, Value} <- [{pid, Pid} | process_info(Pid)]],
     to_bin(Text).
 
@@ -327,7 +334,7 @@ fprof_analyse(Filename) ->
      fprof_preamble(Totals),
      fprof_header(),
      [fprof_entry(Entry) || Entry <- Fns]}.
-    
+
 fprof_preamble({totals, Cnt, Acc, Own}) ->
     fmt("Totals: ~p calls, ~.3f real, ~.3f CPU\n\n", [Cnt, Acc, Own]).
 
@@ -360,16 +367,16 @@ fprof_process_info(Info) ->
     fmt("  ???: ~p~n", [Info]).
 
 fprof_tag({M,F,A}) when is_integer(A) ->
-    to_atom(flatten(io_lib:format("~p:~p/~p", [M,F,A])));
+    to_atom(fmt("~p:~p/~p", [M,F,A]));
 fprof_tag({M,F,A}) when is_list(A) ->
     fprof_tag({M,F,length(A)});
-fprof_tag(Name) when  is_atom(Name) ->
+fprof_tag(Name) when is_atom(Name) ->
     Name.
 
 fprof_mfa({M,F,A}) -> [M,F,A];
 fprof_mfa(_)       -> undefined.
 
-fprof_tag_name(X) -> flatten(io_lib:format("~s", [fprof_tag(X)])).
+fprof_tag_name(X) -> fmt("~s", [fprof_tag(X)]).
 
 fprof_text({Name, Cnt, Acc, Own}) ->
     fmt("~s~p\t~.3f\t~.3f\n",
@@ -384,14 +391,12 @@ fprof_beamfile({M,_,_}) ->
         _ ->
             undefined
     end;
-fprof_beamfile(_)                  -> undefined.
-
-fmt(X, A) -> to_bin(io_lib:format(X, A)).
+fprof_beamfile(_) -> undefined.
 
 pad(X, A) when is_atom(A) ->
     pad(X, to_list(A));
 pad(X, S) when length(S) < X ->
-    S ++ lists:duplicate(X - length(S), $\s);
+    S ++ duplicate(X - length(S), $\s);
 pad(_X, S) ->
     S.
 
@@ -408,39 +413,18 @@ null_gl() ->
 %% Debugging
 %% ----------------------------------------------------------------------
 debug_toggle(Mod, Filename) ->
-    case member(Mod, int:interpreted()) of
-        true ->
-            int:n(Mod),
-            uninterpreted;
-        false ->
-            case code:ensure_loaded(Mod) of
-	        {error,nofile} -> error;
-	        {module,Mod} -> 
-		    case int:i(Mod)  of
-		        {module, Mod} -> interpreted;
-		        error ->
-			    case int:i(Filename)  of
-			        {module, Mod} -> interpreted;
-			        error -> error
-			    end
-		    end
-	    end
+    case is_interpreted(Mod) of
+        true -> int:n(Mod), uninterpreted;
+        false-> int_i(Mod, Filename), interpreted
     end.
 
 debug_add(Modules) ->
-    foreach(fun([_Mod, FileName]) ->
-		    %% FIXME: want to reliably detect whether
-		    %% the module is interpreted, but
-		    %% 'int:interpreted()' can give the wrong
-		    %% answer if code is reloaded behind its
-		    %% back.. -luke
-		    int:i(FileName)
-	    end, Modules),
+    foreach(fun([Mod, Filename]) -> assert_int(Mod, Filename) end, Modules),
     ok.
 
 break_toggle(Mod, Line) ->
-    case lists:any(fun({Point,_}) -> Point == {Mod,Line} end,
-                   int:all_breaks()) of
+    case any(fun({Point,_}) -> Point == {Mod,Line} end,
+             int:all_breaks()) of
         true ->
             ok = int:delete_break(Mod, Line),
             disabled;
@@ -450,7 +434,7 @@ break_toggle(Mod, Line) ->
     end.
 
 break_delete(Mod, Line) ->
-    case lists:any(fun({Point,_}) -> Point == {Mod,Line} end,
+    case any(fun({Point,_}) -> Point == {Mod,Line} end,
                    int:all_breaks()) of
         true ->
             ok = int:delete_break(Mod, Line);
@@ -459,7 +443,7 @@ break_delete(Mod, Line) ->
     end.
 
 break_add(Mod, Line) ->
-    case lists:any(fun({Point,_}) -> Point == {Mod,Line} end,
+    case any(fun({Point,_}) -> Point == {Mod,Line} end,
                    int:all_breaks()) of
         true ->
             ok;
@@ -475,10 +459,6 @@ break_restore(L) ->
       end, L),
     ok.
 
-
-fname(Mod) ->
-    filename:rootname(code:which(Mod), "beam") ++ "erl".
-
 %% Returns: {InterpretedMods, Breakpoints, [{Pid, Text}]}
 %%          InterpretedMods = [[Mod, File]]
 %%          Breakpoints     = [{Mod, Line}]
@@ -486,8 +466,7 @@ debug_subscribe(Pid) ->
     %% NB: doing this before subscription to ensure that the debugger
     %% server is started (int:subscribe doesn't do this, probably a
     %% bug).
-    Interpreted = lists:map(fun(Mod) -> [Mod, fname(Mod)] end,
-                            int:interpreted()),
+    Interpreted = [[Mod, erl_from_mod(Mod)] || Mod <- int_interpreted()],
     spawn_link(?MODULE, debug_subscriber_init, [self(), Pid]),
     receive ready -> ok end,
     int:clear(),
@@ -507,30 +486,77 @@ debug_subscriber_init(Parent, Pid) ->
 
 debug_subscriber(Pid) ->
     receive
-	{int, {new_status, P, Status, Info}} ->
-	    Pid ! {int, {new_status, P, Status, fmt("~w",[Info])}};
-	{int, {new_process, {P, {M,F,A}, Status, Info}}} ->
-	    Pid ! {int, {new_process,
-			 [P,
-			  fmt("~p:~p/~p", [M,F,length(A)]),
-			  Status,
-			  fmt("~w", [Info])]}};
-	{int, {interpret, Mod}} ->
-	    Pid ! {int, {interpret, Mod, fname(Mod)}};
-	Msg ->
-	    Pid ! Msg
+        {int, {new_status, P, Status, Info}} ->
+            Pid ! {int, {new_status, P, Status, fmt("~w",[Info])}};
+        {int, {new_process, {P, {M,F,A}, Status, Info}}} ->
+            Pid ! {int, {new_process,
+                         [P,
+                          fmt("~p:~p/~p", [M,F,length(A)]),
+                          Status,
+                          fmt("~w", [Info])]}};
+        {int, {interpret, Mod}} ->
+            Pid ! {int, {interpret, Mod, erl_from_mod(Mod)}};
+        Msg ->
+            Pid ! Msg
     end,
     debug_subscriber(Pid).
 
 debug_format(Pid, {M,F,A}, Status, Info) ->
-    debug_format_row(io_lib:format("~w", [Pid]),
-                     io_lib:format("~p:~p/~p", [M,F,length(A)]),
-                     io_lib:format("~w", [Status]),
-                     io_lib:format("~w", [Info])).
+    debug_format_row(to_list(fmt("~w", [Pid])),
+                     to_list(fmt("~p:~p/~p", [M,F,length(A)])),
+                     to_list(fmt("~w", [Status])),
+                     to_list(fmt("~w", [Info]))).
 
 debug_format_row(Pid, MFA, Status, Info) ->
     fmt("~-12s ~-21s ~-9s ~-21s~n", [Pid, MFA, Status, Info]).
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% re-implementation of some int.erl functions
+
+erl_from_mod(Mod) ->
+    try {ok,{Mod,[{_,Bin}]}} = beam_lib:chunks(code:which(Mod),["CInf"]),
+        {_,{_,ErlFile}} = lists:keysearch(source,1,binary_to_term(Bin)),
+        ErlFile
+    catch _:_ -> ""
+    end.
+
+
+assert_int(Mod,Filename) ->
+    case is_interpreted(Mod) of
+        true -> ok;
+        false-> int_i(Mod,Filename)
+    end.
+
+int_i(Mod,Srcfile) ->
+    try Beamfile = code:which(Mod),
+        case beam_lib:chunks(Beamfile, [abstract_code,exports]) of
+            {ok,{Mod,[{abstract_code,no_abstract_code},_]}} ->
+                throw(no_debug_info);
+            {ok,{Mod,[{abstract_code,Abst},{exports,Exps}]}} ->
+                int_i(Mod, Exps, Abst, Srcfile, Beamfile)
+        end
+    catch _:R -> throw(R)
+    end.
+
+
+int_i(Mod, Exps, Abst, Srcfile, Beamfile) ->
+    code:purge(Mod),
+    erts_debug:breakpoint({Mod,'_','_'}, false),
+    {module,Mod} = code:load_abs(filename:rootname(Beamfile),Mod),
+    {ok, SrcBin} = file:read_file(Srcfile),
+    {ok, BeamBin} = file:read_file(Beamfile),
+    MD5 = code:module_md5(BeamBin),
+    Bin = term_to_binary({interpreter_module,Exps,Abst,SrcBin,MD5}),
+    {module, Mod} = dbg_iserver:safe_call({load, Mod, Srcfile, Bin}),
+    true = erts_debug:breakpoint({Mod,'_','_'}, true) > 0.
+
+is_interpreted(Mod) ->
+    Mod:module_info(compile) == [].
+
+int_interpreted() ->
+    [Mod || {Mod,Beamfile} <- code:all_loaded(),
+            is_list(Beamfile),
+            is_interpreted(Mod)].
 %% Attach the client process Emacs to the interpreted process Pid.
 %%
 %% spawn_link's a new process to proxy messages between Emacs and
@@ -551,94 +577,94 @@ attach_init(Emacs, Pid) ->
     case int:attached(Pid) of
         {ok, Meta} ->
             attach_loop(#attach{emacs=Emacs,
-				meta=Meta,
-				status=idle,
-				stack={undefined,undefined}});
+                                meta=Meta,
+                                status=idle,
+                                stack={undefined,undefined}});
         error ->
             exit({error, {unable_to_attach, Pid}})
     end.
 
 attach_loop(Att = #attach{emacs=Emacs, meta=Meta}) ->
-    receive 
-	{Meta, {break_at, Mod, Line, Pos}} ->
-	    Att1 = Att#attach{status=break,
-			      where={Mod, Line},
-			      stack={Pos, Pos}},
-	    ?MODULE:attach_loop(attach_goto(Att1,Att1#attach.where));
-	{Meta, Status} when is_atom(Status) ->
-	    Emacs ! {status, Status},
-	    ?MODULE:attach_loop(Att#attach{status=Status,where=undefined});
-	{NewMeta, {exit_at,null,_R,Pos}} when is_pid(NewMeta) ->
-	    %% exit, no stack info
-	    Att1 = Att#attach{status=exit,
-			      where=undefined,
-			      meta=NewMeta,
-			      stack={Pos, Pos}},
-	    ?MODULE:attach_loop(Att1);
-	{NewMeta, {exit_at,{Mod,Line},_R,Pos}} when is_pid(NewMeta) ->
-	    %% exit on error, there is stack info
-	    Att1 = Att#attach{meta = NewMeta,
-			      status=break,
-			      where={Mod,Line},
-			      stack={Pos+1, Pos+1}},
-	    ?MODULE:attach_loop(attach_goto(Att1,Att1#attach.where));
-	{Meta, {attached,_Mod,_Lin,_Flag}} ->
-	    %% happens first time we attach, presumably because we (or
-	    %% someone else) set a break here
-	    ?MODULE:attach_loop(Att);
-	{Meta,{re_entry, Mod, Func}} -> 
-	    Msg = "re_entry "++to_list(Mod)++to_list(Func),
-	    Emacs ! {message, to_bin(Msg)},
-	    ?MODULE:attach_loop(Att);
-	{Meta, _X} ->
-	    %%io:fwrite("distel:attach_loop OTHER meta: ~p~n", [_X]),
-	    %% FIXME: there are more messages to handle, like re_entry
-	    ?MODULE:attach_loop(Att);
-	{emacs, meta, Cmd} when Att#attach.status == break ->
-	    attach_loop(attach_meta_cmd(Cmd, Att));
-	{emacs, meta, _Cmd} ->
-	    Emacs ! {message, <<"Not in break">>},
-	    ?MODULE:attach_loop(Att);
-	_X ->
-	    %%io:fwrite("distel:attach_loop OTHER: ~p~n", [_X]),
-	    ?MODULE:attach_loop(Att)
+    receive
+        {Meta, {break_at, Mod, Line, Pos}} ->
+            Att1 = Att#attach{status=break,
+                              where={Mod, Line},
+                              stack={Pos, Pos}},
+            ?MODULE:attach_loop(attach_goto(Att1,Att1#attach.where));
+        {Meta, Status} when is_atom(Status) ->
+            Emacs ! {status, Status},
+            ?MODULE:attach_loop(Att#attach{status=Status,where=undefined});
+        {NewMeta, {exit_at,null,_R,Pos}} when is_pid(NewMeta) ->
+            %% exit, no stack info
+            Att1 = Att#attach{status=exit,
+                              where=undefined,
+                              meta=NewMeta,
+                              stack={Pos, Pos}},
+            ?MODULE:attach_loop(Att1);
+        {NewMeta, {exit_at,{Mod,Line},_R,Pos}} when is_pid(NewMeta) ->
+            %% exit on error, there is stack info
+            Att1 = Att#attach{meta = NewMeta,
+                              status=break,
+                              where={Mod,Line},
+                              stack={Pos+1, Pos+1}},
+            ?MODULE:attach_loop(attach_goto(Att1,Att1#attach.where));
+        {Meta, {attached,_Mod,_Lin,_Flag}} ->
+            %% happens first time we attach, presumably because we (or
+            %% someone else) set a break here
+            ?MODULE:attach_loop(Att);
+        {Meta,{re_entry, Mod, Func}} ->
+            Msg = "re_entry "++to_list(Mod)++to_list(Func),
+            Emacs ! {message, to_bin(Msg)},
+            ?MODULE:attach_loop(Att);
+        {Meta, _X} ->
+            %%io:fwrite("distel:attach_loop OTHER meta: ~p~n", [_X]),
+            %% FIXME: there are more messages to handle, like re_entry
+            ?MODULE:attach_loop(Att);
+        {emacs, meta, Cmd} when Att#attach.status == break ->
+            attach_loop(attach_meta_cmd(Cmd, Att));
+        {emacs, meta, _Cmd} ->
+            Emacs ! {message, <<"Not in break">>},
+            ?MODULE:attach_loop(Att);
+        _X ->
+            %%io:fwrite("distel:attach_loop OTHER: ~p~n", [_X]),
+            ?MODULE:attach_loop(Att)
     end.
 
 attach_meta_cmd(up, Att = #attach{stack={Pos,Max}}) ->
     case int:meta(Att#attach.meta, stack_frame, {up, Pos}) of
-	{NPos, {undefined, -1},[]} ->  %OTP R10
-	    Att#attach.emacs ! {message, <<"uninterpreted code.">>},
-	    Att#attach{stack={NPos,Max}};
-	{NPos, {Mod, Line},Binds} ->  %OTP R10
-	    attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line},Binds);
-	{NPos, Mod, Line} ->		   %OTP R9
-	    attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line});
-	top ->
-	    Att#attach.emacs ! {message, <<"already at top.">>},
-	    Att
+        {NPos, {undefined, -1},[]} ->  %OTP R10
+            Att#attach.emacs ! {message, <<"uninterpreted code.">>},
+            Att#attach{stack={NPos,Max}};
+        {NPos, {Mod, Line},Binds} ->  %OTP R10
+            attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line},Binds);
+        {NPos, Mod, Line} ->               %OTP R9
+            attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line});
+        top ->
+            Att#attach.emacs ! {message, <<"already at top.">>},
+            Att
     end;
 attach_meta_cmd(down, Att = #attach{stack={_Max,_Max}}) ->
     Att#attach.emacs ! {message, <<"already at bottom">>},
     Att;
 attach_meta_cmd(down, Att = #attach{stack={Pos,Max}}) ->
     case int:meta(Att#attach.meta, stack_frame, {down, Pos}) of
-	{NPos, {undefined, -1},[]} ->  %OTP R10
-	    Att#attach.emacs ! {message, <<"uninterpreted code.">>},
-	    Att#attach{stack={NPos,Max}};
-	{NPos, {Mod, Line},Binds} ->  %OTP R10
-	    attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line},Binds);
-	{NPos, Mod, Line} ->		   %OTP R9
-	    attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line});
-	bottom ->
-	    attach_goto(Att#attach{stack={Max, Max}},Att#attach.where)
+        {NPos, {undefined, -1},[]} ->  %OTP R10
+            Att#attach.emacs ! {message, <<"uninterpreted code.">>},
+            Att#attach{stack={NPos,Max}};
+        {NPos, {Mod, Line},Binds} ->  %OTP R10
+            attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line},Binds);
+        {NPos, Mod, Line} ->               %OTP R9
+            attach_goto(Att#attach{stack={NPos,Max}},{Mod,Line});
+        bottom ->
+            attach_goto(Att#attach{stack={Max, Max}},Att#attach.where)
     end;
 attach_meta_cmd({get_binding, Var}, Att = #attach{stack={Pos,_Max}}) ->
     Bs = int:meta(Att#attach.meta, bindings, Pos),
-    case lists:keysearch(Var, 1, Bs) of
-	{value, Val} ->
-	    Att#attach.emacs ! {show_variable, fmt("~p~n", [Val])};
-	false ->
-	    Att#attach.emacs ! {message, fmt("No such variable: ~p",[Var])}
+    case keysearch(Var, 1, Bs) of
+        {value, Val} ->
+            Att#attach.emacs ! {show_variable, fmt("~p~n", [Val])};
+        false ->
+            Att#attach.emacs ! {message, fmt("No such variable: ~p",[Var])}
     end,
     Att;
 attach_meta_cmd(Cmd, Att) ->
@@ -654,7 +680,7 @@ attach_goto(A = #attach{stack={Pos,Max}},{Mod,Line},Bs) ->
     A.
 stack_pos(#attach{stack={_X,_X}}) -> nostack;
 stack_pos(#attach{stack={Pos,_Max}}) -> Pos.
-    
+
 %% ----------------------------------------------------------------------
 %% Completion support
 %% ----------------------------------------------------------------------
@@ -664,39 +690,37 @@ modules(Prefix) ->
     {ok,Ans} -> {ok,Ans};
     {error,_}-> xref_modules(Prefix)
   end.
-functions(Mod, Prefix) -> 
+functions(Mod, Prefix) ->
   case otp_doc:functions(Mod,Prefix) of
     {ok,Ans} -> {ok,Ans};
     {error,_}-> xref_functions(Mod,Prefix)
   end.
 
--define(COMPLETION_SERVER, distel_complete).
--define(COMPLETION_SERVER_OPTS, {xref_mode, modules}).
+xref_completions(F,A) ->
+    fun(server) -> distel_completions;
+       (opts)   -> [{xref_mode, modules}];
+       (otp)    -> true;
+       (query_) -> to_list(fmt(F,A))
+    end.
 
 rebuild_completions() ->
-    rebuild(?COMPLETION_SERVER, ?COMPLETION_SERVER_OPTS).
+    xref_rebuild(xref_completions("",[])).
 
 %% Returns: [ModName] of all modules starting with Prefix.
 %% ModName = Prefix = string()
 xref_modules(Prefix) ->
-    case  xref_q(?COMPLETION_SERVER, ?COMPLETION_SERVER_OPTS,
-                 '"~s.*" : Mod', [Prefix]) of
-	{ok, Mods} ->
-	    {ok, [atom_to_list(Mod) || Mod <- Mods]};
-	_ ->
-	    {error, fmt("Can't find any matches for ~p", [Prefix])}
+    case xref_query(xref_completions('"~s.*" : Mod', [to_list(Prefix)])) of
+        {ok, Mods} -> {ok, [to_list(Mod) || Mod <- Mods]};
+        _          -> {error, fmt("Can't find any matches for ~p", [Prefix])}
     end.
 
 %% Returns: [FunName] of all exported functions of Mod starting with Prefix.
 %% Mod = atom()
 %% Prefix = string()
 xref_functions(Mod, Prefix) ->
-    case  xref_q(?COMPLETION_SERVER, ?COMPLETION_SERVER_OPTS,
-                 '(X+B) * ~p:"~s.*"/_', [Mod, Prefix]) of
-	{ok, Res} ->
-	    {ok,lists:usort([atom_to_list(Fun) || {_Mod, Fun, _Arity}<-Res])};
-	_ ->
-	    {error, fmt("Can't find module ~p", [Mod])}
+    case xref_query(xref_completions('(X+B) * ~p:"~s.*"/_', [Mod, Prefix])) of
+        {ok, Res} -> {ok,usort([to_list(F) || {_M, F, _A}<-Res])};
+        _         -> {error, fmt("Can't find module ~p", [Mod])}
     end.
 
 %% ----------------------------------------------------------------------
@@ -716,14 +740,13 @@ free_vars(Text) ->
 free_vars(Text, StartLine) ->
     %% StartLine/EndLine may be useful in error messages.
     {ok, Ts, EndLine} = erl_scan:string(Text, StartLine),
-    %%Ts1 = lists:reverse(strip(lists:reverse(Ts))),
+    %%Ts1 = reverse(strip(reverse(Ts))),
     Ts2 = [{'begin', 1}] ++ Ts ++ [{'end', EndLine}, {dot, EndLine}],
     case erl_parse:parse_exprs(Ts2) of
         {ok, Es} ->
             E = erl_syntax:block_expr(Es),
             E1 = erl_syntax_lib:annotate_bindings(E, ordsets:new()),
-            {value, {free, Vs}} = lists:keysearch(free, 1,
-                                                  erl_syntax:get_ann(E1)),
+            {value, {free, Vs}} = keysearch(free, 1, erl_syntax:get_ann(E1)),
             {ok, Vs};
         {error, {_Line, erl_parse, Reason}} ->
             {error, fmt("~s", [Reason])}
@@ -788,30 +811,30 @@ get_arglists(ModName, FunName) when is_list(ModName), is_list(FunName) ->
 
 arglists(Mod, Fun) ->
     case get_abst_from_debuginfo(Mod) of
-	{ok, Abst} ->
-	    case fdecls(to_atom(Fun), Abst) of
-		[] -> error;
-		Fdecls -> map(fun derive_arglist/1, Fdecls)
-	    end;
-	error ->
-	    case beamfile(Mod) of
-		{ok, BeamFile} ->
-		    case get_exports(BeamFile) of
-			{ok, Exports} ->
-			    Funs = [{Fun0, Arity0} || {Fun0, Arity0} <- Exports,
-						      Fun0 == Fun],
-			    case get_forms_from_src(Mod) of
-				{ok, Forms} ->
-				    get_arglist_from_forms(Funs, Forms);
-				_ ->
-				    error
-			    end;
-			_ ->
-			    error
-		    end;
-		_ ->
-		    error
-	    end
+        {ok, Abst} ->
+            case fdecls(to_atom(Fun), Abst) of
+                [] -> error;
+                Fdecls -> map(fun derive_arglist/1, Fdecls)
+            end;
+        error ->
+            case beamfile(Mod) of
+                {ok, BeamFile} ->
+                    case get_exports(BeamFile) of
+                        {ok, Exports} ->
+                            Funs = [{Fun0, Arity0} || {Fun0, Arity0} <- Exports,
+                                                      Fun0 == Fun],
+                            case get_forms_from_src(Mod) of
+                                {ok, Forms} ->
+                                    get_arglist_from_forms(Funs, Forms);
+                                _ ->
+                                    error
+                            end;
+                        _ ->
+                            error
+                    end;
+                _ ->
+                    error
+            end
     end.
 
 %% Find the {function, ...} entry for the named function in the
@@ -820,47 +843,47 @@ arglists(Mod, Fun) ->
 fdecls(Name, Abst) ->
     {_Exports,Forms} = Abst,
     [Fdecl || Fdecl <- Forms,
-	      element(1, Fdecl) == function,
-	      element(3, Fdecl) == Name].
+              element(1, Fdecl) == function,
+              element(3, Fdecl) == Name].
 
 %% Get the abstrct syntax tree for `Mod' from beam debug info.
 %% Return: {ok, Abst} | error
 get_abst_from_debuginfo(Mod) ->
     case beamfile(Mod) of
-	{ok, Filename} ->
-	    case read_abst(Filename) of
-		{ok, Abst} ->
-		    {ok, binary_to_term(Abst)};
-		error ->
-		    error
-	    end;
-	error ->
-	    error
+        {ok, Filename} ->
+            case read_abst(Filename) of
+                {ok, Abst} ->
+                    {ok, binary_to_term(Abst)};
+                error ->
+                    error
+            end;
+        error ->
+            error
     end.
 
 get_forms_from_src(Mod) ->
     case find_source(Mod) of
-	{ok, SrcFName} ->
-	    epp_dodger:parse_file(SrcFName);
-	_ ->
-	    error
+        {ok, SrcFName} ->
+            epp_dodger:parse_file(SrcFName);
+        _ ->
+            error
     end.
 
 %% Return the name of the beamfile for Mod.
 beamfile(Mod) ->
     case code:which(Mod) of
-	File when is_list(File) ->
-	    {ok, File};
-	_ ->
-	    error
+        File when is_list(File) ->
+            {ok, File};
+        _ ->
+            error
     end.
 
 %% Read the abstract syntax tree from a debug info in a beamfile.
 read_abst(Beam) ->
     case beam_lib:chunks(Beam, ["Abst"]) of
-	{ok, {_Mod, [{"Abst", Abst}]}} when Abst /= <<>> ->
-	    {ok, Abst};
-	_ -> error
+        {ok, {_Mod, [{"Abst", Abst}]}} when Abst /= <<>> ->
+            {ok, Abst};
+        _ -> error
     end.
 
 %% Derive a good argument list from a function declaration.
@@ -879,8 +902,8 @@ clause_args({clause, _Line, Args, _Guard, _Body}) ->
 %% variable name).
 argname({var, _Line, V}) ->
     case to_list(V) of
-	"_"++_ -> unknown;
-	_      -> V
+        "_"++_ -> unknown;
+        _      -> V
     end;
 argname({Type, _Line, _})          -> to_list(Type)++"()";
 argname({nil, _Line})              -> "list()";
@@ -901,11 +924,11 @@ best_arg(Args) ->
 %% 'unknown' useless, type description is better, variable name is best.
 best_arg(unknown, A2)          -> A2;
 best_arg(A1, unknown)          -> A1;
-best_arg(A1, A2) when is_atom(A1),is_atom(A2) ->
+best_arg(A1, A2) when is_atom(A1), is_atom(A2) ->
     %% ... and the longer the variable name the better
     case length(to_list(A2)) > length(to_list(A1)) of
-	true -> A2;
-	false -> A1
+        true -> A2;
+        false -> A1
     end;
 best_arg(A1, _A2) when is_atom(A1) -> A1;
 best_arg(_A1, A2)               -> A2.
@@ -921,15 +944,15 @@ get_arglist_from_forms(Funs, Forms) ->
 
 src_args(_, _, 0) -> [];
 src_args([{tree,function,_,{function,{tree,atom,_,Func}, Clauses}} = H | T],
-	 Func, Arity) ->
+         Func, Arity) ->
     case erl_syntax_lib:analyze_function(H) of
-	{_, Arity} ->
-	    ArgsL0 = [Args || {tree, clause, _, {clause,Args,_,_}} <- Clauses],
-	    ArgsL1 = [map(fun argname/1, Args) || Args <- ArgsL0],
-	    Args = merge_args(ArgsL1),
-	    map(fun to_list/1, Args);
-	_ ->
-	    src_args(T, Func, Arity)
+        {_, Arity} ->
+            ArgsL0 = [Args || {tree, clause, _, {clause,Args,_,_}} <- Clauses],
+            ArgsL1 = [map(fun argname/1, Args) || Args <- ArgsL0],
+            Args = merge_args(ArgsL1),
+            map(fun to_list/1, Args);
+        _ ->
+            src_args(T, Func, Arity)
     end;
 src_args([_ |T], Func, Arity) ->
     src_args(T, Func, Arity).
@@ -937,11 +960,11 @@ src_args([_ |T], Func, Arity) ->
 
 get_exports(BeamFile) ->
     case beam_lib:chunks(BeamFile, ["Atom", "ExpT"]) of
-	{ok, {_, [{"Atom", AtomBin}, {"ExpT", ExpBin}]}} ->
-	    Atoms = beam_disasm_atoms(AtomBin),
-	    {ok, beam_disasm_exports(ExpBin, Atoms)};
-	_ ->
-	    error
+        {ok, {_, [{"Atom", AtomBin}, {"ExpT", ExpBin}]}} ->
+            Atoms = beam_disasm_atoms(AtomBin),
+            {ok, beam_disasm_exports(ExpBin, Atoms)};
+        _ ->
+            error
     end.
 %%-----------------------------------------------------------------------
 %% BEGIN Code snitched from beam_disasm.erl; slightly modified
@@ -965,7 +988,7 @@ get_atom_name(Len,Xs) ->
 get_atom_name(N,[X|Xs],RevName) when N > 0 ->
     get_atom_name(N-1,Xs,[X|RevName]);
 get_atom_name(0,Xs,RevName) ->
-    { lists:reverse(RevName), Xs }.
+    { reverse(RevName), Xs }.
 
 beam_disasm_exports(none, _) -> none;
 beam_disasm_exports(ExpTabBin, Atoms) ->
@@ -1007,65 +1030,32 @@ get_int(B) ->
 %%-----------------------------------------------------------------
 %% Call graph
 %%-----------------------------------------------------------------
--define(CALL_GRAPH_SERVER, distel_call_graph).
--define(CALL_GRAPH_SERVER_OPTS, []).
+
+xref_callgraph(A) ->
+    F = to_list(fmt("(XXL)(Lin)(E || ~p)",[A])),
+    fun(server)-> distel_call_graph;
+       (opts) -> [];
+       (otp) -> false;
+       (query_)-> F
+    end.
+
+%% Ret: [{M,F,A,Line}], M = F = list()
+who_calls(Mm, Fm, Am) ->
+    try XREF=xref_callgraph({Mm,Fm,Am}),
+        {ok, Calls} = xref_query(XREF),
+        append([[xform(M,F,A,L) || L <- Ls] || {{{{M,F,A},_},_}, Ls} <- Calls])
+    catch _:_ ->
+        {error,not_found}
+    end.
+
+xform(M, F, A, L) ->
+  {to_list(M),to_list(F),A,L}.
 
 rebuild_call_graph() ->
-    rebuild(?CALL_GRAPH_SERVER, ?CALL_GRAPH_SERVER_OPTS).
-
-%% Ret: [{M,F,A,Line}], M = F = binary()
-who_calls(M, F, A) ->
-    [{fmt("~p", [Mod]), fmt("~p", [Fun]), Aa, Line}
-     || {{Mod,Fun,Aa},Line} <- calls_to({M, F, A})].
-
-%% {M,F,A} -> [{{M,F,A},Line}]
-calls_to(MFA) ->
-    {ok, Calls} = xref_q(?CALL_GRAPH_SERVER, ?CALL_GRAPH_SERVER_OPTS,
-			 "(XXL)(Lin)(E || ~p)", [MFA]),
-    lists:flatten([[{Caller, Line} || Line <- Lines]
-		   || {{{Caller,_},_}, Lines} <- Calls]).
-
-string_format(S) -> S.
-string_format(S, A) -> lists:flatten(io_lib:fwrite(S, A)).
-
-%%-----------------------------------------------------------------
-%% Support code for completion and call graph
-%%-----------------------------------------------------------------
-
-rebuild(Server, Opts) ->
-    stop(Server),
-    ensure_started(Server, Opts).
-
-stop(Server) ->
-    case whereis(Server) of
-        undefined -> ok;
-        _ -> xref:stop(Server),
-             ok
-    end.
-
-xref_q(Server, Opts, Query, Args) ->
-    ensure_started(Server, Opts),
-    xref:q(Server, string_format(Query, Args)).
-
-ensure_started(Server, Opts) ->
-    case whereis(Server) of
-	undefined ->
-            xref:start(Server, Opts),
-	    xref:set_default(Server, builtins, true),
-            foreach(fun (Dir) -> xref:add_directory(Server, Dir) end,
-                    get_code_path());
-	_ ->
-	    xref:update(Server),
-            ok
-    end.
-
-%% FIXME: make pruning configurable, e.g. remove all otp apps
-get_code_path() ->
-    code:get_path().
-
+    xref_rebuild(xref_callgraph("")).
 %%-----------------------------------------------------------------
 %% Call graph mode:
-%% 
+%%
 %% Callers of foo:bar/2
 %%   + baz:doit/3
 %%     foo:baz/0
@@ -1078,3 +1068,38 @@ get_code_path() ->
 %%   'ret' on a '-' line collapses
 %%    ?? jump to definition in other buffer
 %%-----------------------------------------------------------------
+
+xref_query(XREF) ->
+    ensure_started(XREF),
+    xref:q(XREF(server), XREF(query_)).
+
+xref_rebuild(XREF) ->
+    stop(XREF),
+    ensure_started(XREF).
+
+ensure_started(XREF) ->
+    case whereis(XREF(server)) of
+        undefined -> start(XREF);
+        _         -> xref:update(XREF(server))
+    end.
+
+stop(XREF) ->
+    case whereis(XREF(server)) of
+        undefined -> ok;
+        _         -> xref:stop(XREF(server))
+    end.
+
+start(XREF) ->
+    xref:start(XREF(server), XREF(opts)),
+    xref:set_default(XREF(server), builtins, true),
+    F = fun(D) -> xref:add_directory(XREF(server), D) end,
+    foreach(F, get_code_path(XREF)).
+
+get_code_path(XREF) ->
+    case XREF(otp) of
+        false->
+            Root = code:root_dir(),
+            [Dir || Dir <- code:get_path(), not prefix(Root,Dir)];
+        true ->
+            code:get_path()
+    end.

--- a/src/distel_ie.erl
+++ b/src/distel_ie.erl
@@ -1,0 +1,384 @@
+%
+%%% distel_ie - an interactive erlang shell
+%%%
+%%% Some of the code has shamelessly been stolen from Luke Gorrie 
+%%% [luke@bluetail.com] - ripped from its elegance and replaced by bugs. 
+%%% It just goes to show that you can't trust anyone these days. And
+%%% as if that wasn't enough, I'll even blame Luke: "He _made_ me do it!"
+%%%
+%%% So, without any remorse, I hereby declare this code to be:
+%%%
+%%% copyright (c) 2002 david wallin [david.wallin@ul.ie].
+%%%
+%%% (it's probably going to be released onto an unexpecting public under
+%%%  some sort of BSD license).
+%%%
+%%%@hidden
+%%%@private
+
+-module(distel_ie).
+
+-export([
+	 evaluate/2,
+
+	 test1/0,
+	 test2/0,
+	 test3/0,
+	 test4/0,
+	 test5/0,
+
+	 ensure_registered/0,
+
+	 start/0,
+	 start/1,
+	 init/1,
+	 loop/1
+	]).
+
+-define(FMT(X), list_to_binary(lists:flatten(io_lib:format("~p", [X])))).
+
+
+%%
+%% ensure_registered/0
+ensure_registered() ->
+    case whereis(distel_ie) of
+ 	undefined -> start() ;
+ 	Pid  ->
+	    group_leader(group_leader(), Pid),
+	    ok
+    end.
+
+%%
+%% start/0
+
+start() ->
+    start([]).
+
+
+%%
+%% start/1
+
+start(Options) ->
+    spawn(?MODULE, init, [Options]).
+
+
+%%
+%% init/1
+
+init(_Options) ->
+    register(distel_ie, self()),
+    Defs = ets:new(definitions, [set]),
+    Line = 12,
+    Bindings = [],
+    State = {Defs, Line, Bindings},
+    loop(State).
+
+
+%%
+%% loop/1
+
+loop({Defs, Line, Bindings}) ->
+    receive 
+	{evaluate, Emacs, String} -> 
+	    case catch evaluate(String, {Defs, Line, Bindings}) of
+		{'EXIT', Rsn} ->
+		    Emacs ! {ok, list_to_binary(
+				   io_lib:format("EXIT: ~p", [Rsn]))},
+		    ?MODULE:loop({Defs, Line, Bindings});
+		{Result, {NL, NB}} ->
+		    Emacs ! Result,
+		    ?MODULE:loop({Defs, NL, NB})
+	    end;
+	forget_bindings ->
+	    put(distel_ie_bindings, []),
+	    ?MODULE:loop({Defs, Line, []}) ;
+	Unknown ->
+	    io:format("distel_ie: unknown message recvd '~p'\n", [Unknown]),
+	    ?MODULE:loop({Defs, Line, Bindings})
+
+    end.
+
+
+%%
+%% evaluate/2
+
+evaluate(String, {Defs, Line, Bindings}) ->
+    case parse_expr(String) of
+	%% ok, so it is an expression :
+	{ok, Parse} ->
+	    RemoteParse = add_remote_call_info(Parse, Defs),
+            case catch erl_eval:exprs(RemoteParse, Bindings) of
+                {value, V, NewBinds} ->
+		    {{ok, ?FMT(V)}, {Line, NewBinds}};
+                Error ->
+		    {?FMT(Error), {Line, Bindings}}
+	    end;
+	%% try and treat it as a form / definition instead :
+	Other ->
+	    case parse_form(String) of
+		{ok, Parse} -> 
+		    {ok, Name, Arity} = get_function_name(Parse),
+		    ets:insert(Defs, {Name, Parse}),
+		    FunTrees = lists:flatten(
+				 lists:reverse(ets:match(Defs,{'_', '$1'}))),
+		    %% Line isn't really used yet
+		    NewLine = Line,
+		    compile_load(FunTrees),
+		    Def = list_to_binary(atom_to_list(Name) ++ "/" ++ 
+					 integer_to_list(Arity)),
+		    {{ok, Def}, {NewLine, Bindings}} ;
+		Error ->
+		    {{error, ?FMT({Error, Other})}, {Line, Bindings}}
+	    end
+    end.
+
+%%
+%% parse_expr/1
+
+parse_expr(String) ->
+    case erl_scan:string(String) of
+	{ok, Tokens, _} ->
+	    catch erl_parse:parse_exprs(Tokens) ;
+	{error, {_Line, erl_parse, Rsn}} ->
+	    {error, lists:flatten(Rsn)};
+	{error, Error, _} ->
+	    {error, Error}
+    end.
+
+%%
+%% parse_form/1
+
+parse_form(String) ->
+    case erl_scan:string(String) of
+	{ok, Tokens, _} ->
+	    catch erl_parse:parse_form(Tokens) ;
+	{error, {_Line, erl_parse, Rsn}} ->
+	    {error, lists:flatten(Rsn)};
+	{error, Error, _} ->
+	    {error, Error}
+    end.
+
+
+%%
+%% defun/1
+
+defun(String) ->
+    {ok, Tokens, _} = erl_scan:string(String),
+    {ok, Parse} = erl_parse:parse_form(Tokens),
+    compile_load([Parse]).
+
+
+%%
+%% compile_load/1
+
+compile_load(Parse) ->
+
+    Header = [{attribute,9,module,distel_ie_internal},
+	      {attribute,11,compile,export_all},
+	      {attribute,12,export,[]}],
+
+    EOF = [{eof,20}],
+
+    SyntaxTree = Header ++ Parse ++ EOF,
+
+    {ok, Mod, Binary} = compile:forms(SyntaxTree),
+    File = "heltigenomfelfelsomfansomentyskindianenbefjadradgerman",
+    code:load_binary(Mod, File, Binary).
+
+
+%%
+%% add_remote_call_info/2
+%%
+%% TODO: this is gonna need more work, e.g. it needs to recurse into 
+%% lists (cons) and tuples ... +more
+
+add_remote_call_info([], _Defs) -> [] ;
+add_remote_call_info({var, L, Var}, _Defs) ->
+    {var, L, Var} ;
+add_remote_call_info({atom, L, Atom}, _Defs) ->
+    {atom, L, Atom} ;
+add_remote_call_info({integer, L, Value}, _Defs) ->
+    {integer, L, Value} ;
+add_remote_call_info({string, L, String}, _Defs) ->
+    {string, L, String} ;
+add_remote_call_info([{call, L, {atom, L2, Name}, Body} | Rs], Defs) ->
+    B = add_remote_call_info(Body, Defs),
+    IsBuiltin = erlang:is_builtin(erlang, Name, length(B)),
+    Call = case IsBuiltin of 
+	       true ->
+		   {call, L, {atom, L2, Name}, B} ;
+	       false ->
+		   Arity = length(Body),
+		   case find_module(Name, Arity) of 
+		       {ok, Mod} ->
+	 		   {call, L, {remote, L2, 
+				      {atom, L2, Mod}, 
+				      {atom, L2, Name}}, B} ;
+		       {error, _} ->
+			   {call, L, {atom, L2, Name}, B}
+		   end
+	   end,
+    [Call | add_remote_call_info(Rs, Defs)] ;
+
+add_remote_call_info([{tuple, L, Values} | Rs], Defs) ->
+    F = fun(X) -> add_remote_call_info(X, Defs) end,
+    [{tuple, L, lists:map(F, Values)} | add_remote_call_info(Rs, Defs)] ;
+
+
+add_remote_call_info([{Type, L, Hdr, Body} | Rs], Defs) when is_list(Body) ->
+    B = add_remote_call_info(Body, Defs),
+    [{Type, L, Hdr, B} | add_remote_call_info(Rs, Defs)] ;
+
+add_remote_call_info([{Type, L, Hd, Tl} | Rs], Defs) ->
+    [{Type, L, Hd, Tl} | add_remote_call_info(Rs, Defs)] ;
+
+add_remote_call_info([R | Rs], Defs) ->
+    [add_remote_call_info(R, Defs) | add_remote_call_info(Rs, Defs) ];
+
+add_remote_call_info(X, _Defs) ->
+    X.
+
+
+%%
+%% find_module/2
+
+find_module(Function, Arity) ->
+    Mods = [distel_ie_internal, distel_ie, c],
+    F = fun(M) -> not is_exported(Function, Arity, M) end,
+    case lists:dropwhile(F, Mods) of
+	[] ->
+	    search_modules(Function, Arity, code:all_loaded()) ;
+	[M | _] ->
+	    {ok, M}
+    end.
+
+
+%%
+%% is_exported/3
+
+is_exported(Function, Arity, Module) ->
+    case code:is_loaded(Module) of
+	false ->
+	    false;
+	_ ->
+	    Info = Module:module_info(),
+	    {value, {exports, Exports}} = lists:keysearch(exports, 1, Info),
+	    lists:member({Function, Arity}, Exports)
+    end.
+
+
+%%
+%% search_modules/3
+
+search_modules(_Function, _Arity, []) ->
+    {error, not_found};
+search_modules(Function, Arity, [{M, _} | Ms]) ->
+    case is_exported(Function, Arity, M) of
+	true ->
+	    {ok, M} ;
+	false ->
+	    search_modules(Function, Arity, Ms)
+    end.
+    
+
+%%
+%% get_function_name/1
+
+get_function_name({function, _, Name, Arity, _}) -> 
+    {ok, Name, Arity} ;
+
+get_function_name(Unknown) ->
+    {error, Unknown}.
+
+
+%%% ------------------------------------------------------------------- [tests]
+    
+%%
+%% test1/0
+
+test1() ->
+    Defun = "sista(W) -> lists:last(W).",
+    defun(Defun).
+
+%%
+%% test2/0
+
+test2() ->
+    
+    Prefix = [
+	      {attribute,9,module,compile_and_load_me},
+	      {attribute,11,compile,export_all},
+	      {attribute,12,export,[]}
+	     ],
+    
+    Postfix = [{eof,20}],
+    
+    String = "sista([]) -> [] ;\n\nsista(W) -> lists:last(W).\n",
+%    String = "sista([], _) -> [] ;\n\nsista(W, _) -> lists:last(W).\n",
+    
+    {ok, Tokens, _} = erl_scan:string(String, 23),
+    {ok, Tree} = erl_parse:parse_form(Tokens),
+    
+    io:format("tree : '~p'\n", [Tree]),
+    
+    SyntaxTree = Prefix ++ [Tree] ++ Postfix,
+    
+    io:format("syntaxtree : '~p'\n", [SyntaxTree]),
+    
+    {ok, Mod, Binary} = compile:forms(SyntaxTree),
+    code:load_binary(Mod, "spam", Binary),
+    compile_and_load_me:sista([1,2,galapremiere]).
+
+
+%%
+%% test3/0
+
+test3() ->
+
+    Sista = "sista(W) -> lists:last(W).\n",
+    defun(Sista),
+    distel_ie_internal:sista([1,2,galapremiere]),
+    NySista = "en_till_sista(W) -> lists:last(W).\n",
+    defun(NySista),
+    distel_ie_internal:en_till_sista([1,2,onestepbeyond]).
+
+
+%%
+%% test4/0
+
+test4() ->
+
+    Defs = ets:new(definitions, [set]),
+
+    Define = "nisse([]) -> [] ;\n\nnisse(W) -> lists:last(W).",
+    Expr = "nisse([1,2,3]).",
+%    Expr = "distel_ie_internal:nisse([1,2,3]).",
+%    Expr = "lists:last([1,2,3]).",
+    
+    D = evaluate(Define, {Defs, 10, []}),
+    io:format("nisse defined: '~p'\n", [D]),
+    io:format("is_loaded: '~p'\n", [code:is_loaded(distel_ie_internal)]),
+    evaluate(Expr, {Defs, 10, []}).
+
+
+%%
+%% test5/0
+
+test5() ->
+
+    Defs = ets:new(definitions, [set]),
+    
+    Define = "nisse([]) -> [] ;\n\nnisse(W) -> lists:last(W).",
+    Expr = "nisse([1,2,3]).",
+
+    evaluate(Define, {Defs, 10, []}),
+%    ets:insert(Defs, {nisse, nil}),
+
+    {ok, Tokens, _} = erl_scan:string(Expr, 23),
+    {ok, Tree} = erl_parse:parse_exprs(Tokens),
+
+    io:format("original tree : '~p'\n", [Tree]),
+    
+    RemoteTree = add_remote_call_info(Tree, Defs),
+    io:format("remote tree : '~p'\n", [RemoteTree]).
+

--- a/src/fdoc.erl
+++ b/src/fdoc.erl
@@ -1,0 +1,350 @@
+%%%----------------------------------------------------------------------
+%%% File    : fdoc.erl
+%%% Author  : Luke Gorrie <luke@bluetail.com>
+%%% Purpose : Heuristic sourcecode documentation extractor
+%%%           (A poor man's 'edoc')
+%%% Created : 26 Feb 2003 by Luke Gorrie <luke@bluetail.com>
+%%%----------------------------------------------------------------------
+%%%@hidden
+%%%@private
+-module(fdoc).
+-author('luke@bluetail.com').
+
+-import(lists,
+	[reverse/1, splitwith/2, takewhile/2, flatten/1, map/2,
+	 foreach/2, member/2, sort/1, any/2]).
+
+%% Server-based interface
+-export([apropos/1, get_apropos/1,
+	 describe/1, describe/2, describe/3,
+	 description/1, description/2, description/3,
+	 stop/0]).
+
+%% Function-based interface
+-export([describe_file/1, file/1, string/1]).
+-export([describe2/1, describe2/2, describe2/3]).
+
+%% Internal server exports
+-export([init/0,loop/0]).
+
+%% ----------------------------------------------------------------------
+%% Server half. Calling these functions causes a server to be created,
+%% which scans the sources for all loaded modules. You can use stop()
+%% to shut it down, so that the next request will rebuild the database.
+%% ----------------------------------------------------------------------
+
+%% Interface
+
+%% Print apropos information by regexp.
+apropos(Regexp) ->
+    case get_apropos(Regexp) of
+	{ok, Matches} ->
+	    print_matches(Matches);
+	Err ->
+	    Err
+    end.
+
+get_apropos(Regexp) ->
+    ensure_started(),
+    case regexp:parse(Regexp) of
+	{ok, RE} ->
+	    fdoc ! {apropos, self(), RE},
+	    receive
+		{apropos, Matches} ->
+		    {ok, Matches}
+	    end;
+	Err ->
+	    Err
+    end.
+
+%% Print a description of all functions matching Module, Function, and
+%% Arity. Function and module arguments are optional.
+
+describe(M) ->
+    describe(M, '_', '_').
+describe(M, F) ->
+    describe(M, F, '_').
+describe(M, F, A) ->
+  {ok, Matches} = description(M, F, A),
+  print_matches(Matches).
+
+description(M) ->
+    description(M, '_', '_').
+
+description(M, F) ->
+    description(M, F, '_').
+
+description(M, F, A) ->
+    ensure_started(),
+    fdoc ! {describe, self(), M, F, A},
+    receive
+	{describe, Matches} -> {ok, Matches}
+    end.
+
+%% This function does not use the cache
+describe2(M) ->
+    describe2(M, '_', '_').
+describe2(M, F) ->
+    describe2(M, F, '_').
+describe2(M, F, A) ->
+    case distel:find_source(M) of
+	{ok, Sourcefile} ->
+	    case file(Sourcefile) of
+		{ok, Docs} ->
+		    {ok, lists:zf(fun({Fn, Arity, DocStr}) when F=='_'; Fn==F ->
+					  if A == '_'; A == Arity ->
+						  {true, {M,Fn, Arity, DocStr}};
+					     true ->
+						  false
+					  end;
+				     (_) ->
+					  false
+				  end, Docs)};
+		Error ->
+		    Error
+	    end;
+	Error ->
+	    Error
+    end.
+
+
+%% Stop the fdoc server. You can use this to flush the database.
+stop() ->
+    catch (fdoc ! {stop, self()}),
+    receive {stop, ok} -> ok end.
+
+%% Internals
+
+print_matches(Ms) ->
+    foreach(fun({Mod, Fn, Arity, Doc}) ->
+		    io:format("~p:~p/~p:~n~s~n",
+			      [Mod, Fn, Arity, indent(Doc, "  ")])
+	    end,
+	    sort(Ms)).
+
+%% Ensure that the 'fdoc' server has started.
+ensure_started() ->
+    case whereis(?MODULE) of
+	undefined ->
+	    Pid = proc_lib:spawn(?MODULE, init, []),
+	    register(?MODULE, Pid),
+	    {ok, Pid};
+	Pid ->
+	    {ok, Pid}
+    end.
+
+init() ->
+    init_db(),
+    loop().
+
+init_db() ->
+    ets:new(?MODULE, [public, bag, named_table]),
+    foreach(fun import_module/1, [M || {M, _Objfile} <- code:all_loaded()]).
+
+loop() ->
+    receive
+	{stop, From} ->
+	    From ! {stop, ok},
+	    ok;
+	{apropos, From, RE} ->
+	    Matches = [{M,F,A,D} || {M,F,A,D} <- ets:tab2list(?MODULE),
+				    any(fun(S) ->
+						regexp:match(S, RE) /= nomatch
+					end,
+					[D,
+					 atom_to_list(M),
+					 atom_to_list(F)])],
+	    From ! {apropos, Matches},
+	    ?MODULE:loop();
+	{describe, From, M, F, A} ->
+	    case code:is_loaded(M) of
+		false ->
+		    %% Have to reload the database first..
+		    code:ensure_loaded(M),
+		    ets:delete(?MODULE),
+		    init_db();
+		_ ->
+		    ok
+	    end,
+	    From ! {describe, ets:match_object(?MODULE, {M, F, A, '_'})},
+	    ?MODULE:loop()
+    end.
+
+import_module(Mod) ->
+    case distel:find_source(Mod) of
+	{ok, Sourcefile} ->
+	    case file(Sourcefile) of
+		{ok, Docs} ->
+		    foreach(fun({Fn, Arity, DocStr}) ->
+				    ets:insert(?MODULE,{Mod,Fn,Arity,DocStr})
+			    end,
+			    just_exports(Mod, Docs));
+		{error, _Reason} ->
+		    skipped
+	    end;
+	{error, _Reason} ->
+	    skipped
+    end.
+
+just_exports(Mod, Docs) ->
+    [{F,A,D} || {F,A,D} <- Docs,
+		member({F, A}, Mod:module_info(exports))].
+
+%% ----------------------------------------------------------------------
+%% Function half, for extracting documentation from files and strings.
+%% ----------------------------------------------------------------------
+
+%% Interface
+
+%% Print a description of all the documented exported functions in a
+%% file.
+describe_file(Name) ->
+    case file(Name) of
+	{ok, Docs} ->
+	    foreach(fun({Fn, Arity, Doc}) ->
+			    io:format("~p/~p:~n~s~n",
+				      [Fn, Arity, indent(Doc, "  ")])
+		    end,
+		    Docs);
+	{error, Rsn} ->
+	    {error, Rsn}
+    end.
+
+%% Return a description of all documented exported functions in
+%% a file.
+%% Returns: {Function, Arity, Documentation}
+file(Name) ->
+    case file:read_file(Name) of
+	{ok, Bin} ->
+	    {ok, string(binary_to_list(Bin))};
+	{error, Reason} ->
+	    {error, Reason}
+    end.
+
+%% Return a description of all documented exported functions in
+%% a string.
+%% Returns: {Function, Arity, Documentation}
+string(S) ->
+    remove_dups(scan_lines(S, [])).
+
+%% Internals
+
+%% If we have multiple definitions of the same function/arity, just
+%% keep the first one.
+remove_dups([{F,A,Doc}, {F,A,_} | T]) ->
+    remove_dups([{F,A,Doc}|T]);
+remove_dups([H|T]) ->
+    [H|remove_dups(T)];
+remove_dups([]) ->
+    [].
+
+scan_lines([], _) ->
+    [];
+scan_lines(S0, Acc) when hd(S0) == $% ->
+    {CommentLine, S1} = take_line(S0),
+    scan_lines(S1, [CommentLine|Acc]);
+scan_lines("\n"++S, _Acc) when hd(S) == $% ->
+    %% Blank followed by a new comment: flush old comment
+    scan_lines(S, []);
+scan_lines("\n"++S, Acc) ->
+    %% Blank not followed by a comment: keep the current comment
+    scan_lines(S, Acc);
+scan_lines(S0, Acc) ->
+    case function_start_char(hd(S0)) of
+	true ->
+	    scan_function(S0, comments_to_doc(reverse(Acc)));
+	false ->
+	    scan_lines(drop_line(S0), [])
+    end.
+
+scan_function(S0, Comments) ->
+    case take_function_head(S0) of
+	{ok, Head, S1} ->
+	    S2 = drop_line(S1),		% skip to next fresh line
+	    case parse_function_head(Head) of
+		{ok, Function, Arity} ->
+		    if Comments == [] ->
+			    scan_lines(S2, []);
+		       true ->
+			    [{Function, Arity, Comments} | scan_lines(S2, [])]
+		    end;
+		error ->
+		    scan_lines(S2, [])
+	    end;
+	eos ->
+	    []
+    end.
+
+function_start_char(Ch) when Ch >= $a, Ch =< $z -> true;
+function_start_char(Ch) when Ch >= $A, Ch =< $Z -> true;
+function_start_char($')                         -> true;
+function_start_char(_)                          -> false.
+
+%% Parse a function head into name and arity.
+%% Returns: {ok, Name, Arity} | error
+parse_function_head(S0) ->
+    %% Poor man's approach: rewind back to the closing ')', tack on a
+    %% '.', and see if we can parse it as a function call.
+    S1 = takewhile(fun(Ch) -> Ch /= $) end, S0) ++ ").",
+    case erl_scan:string(S1) of
+	{ok, Scan, _} ->
+	    case erl_parse:parse_exprs(Scan) of
+		{ok, [{call,_,{atom,_,Fname},Args}]} ->
+		    {ok, Fname, length(Args)};
+		_ ->
+		    error
+	    end;
+	_ ->
+	    error
+    end.
+
+%% Keep going until we see a "->". FIXME, should be clever about "->"
+%% appearing inside comments, atoms, or strings.
+take_function_head(S) -> take_function_head(S, []).
+
+take_function_head("->"++S, Acc) ->
+    {ok, reverse(Acc), S};
+take_function_head("%"++S0, Acc) ->
+    {_, S1} = take_line(S0),
+    take_function_head(S1, Acc);
+take_function_head([H|T], Acc) ->
+    take_function_head(T, [H|Acc]);
+take_function_head([], _Acc) ->
+    eos.
+
+%% Returns: {Line, Rest}
+take_line(S) -> take_line(S, []).
+
+take_line([],      Acc) -> {reverse(Acc), []};
+take_line([$\n|S], Acc) -> {reverse("\n"++Acc), S};
+take_line([H|T],   Acc) -> take_line(T, [H|Acc]).
+
+drop_line(S0) ->
+    {_, S1} = take_line(S0),
+    S1.
+
+comments_to_doc([]) ->
+    [];
+    %% FIXME: we should really generate nothing here, since zillions
+    %% of these "undocumented" strings will match e.g. an apropos
+    %% search for "documented" :-) -luke
+%    "(undocumented)\n";
+comments_to_doc(Comments) ->
+    flatten([Line || Line <- map(fun clean_comment/1, Comments),
+		     not boring_comment(Line)]).
+
+boring_comment("\n") -> true;
+boring_comment(S) ->
+    %% Matches "%% ----------" lines
+    lists:all(fun(Ch) -> Ch == $- end, S -- "\n").
+
+clean_comment("% "++S) -> S;
+clean_comment("%"++S)  -> clean_comment(S);
+clean_comment(S)       -> S.
+
+indent(S, Pad) -> flatten([Pad | indent1(S, Pad)]).
+
+indent1("\n"++S, Pad) -> ["\n", Pad, indent1(S, Pad)];
+indent1([H|T], Pad)   -> [H|indent1(T, Pad)];
+indent1([], _)        -> [].
+

--- a/src/otp_doc.erl
+++ b/src/otp_doc.erl
@@ -1,0 +1,338 @@
+%% -*- erlang-indent-level: 2 -*-
+%%% Created :  6 Mar 2008 by Mats Cronqvist <masse@kreditor.se>
+%%%@hidden
+%%%@private
+
+%% @doc
+%% @end
+
+-module('otp_doc').
+-author('Mats Cronqvist').
+
+-define(is_str(S),(S==[] orelse is_integer(hd(S)))).
+%% --------------------------------------------------------------------------
+%% gen_server boilerplate
+-behaviour(gen_server).
+-export([handle_call/3, handle_cast/2, handle_info/2, 
+         init/1, terminate/2, code_change/3]).
+%% --------------------------------------------------------------------------
+% API - these run in the shell
+-export([start/0,stop/0]).
+-export([distel/4,modules/1,functions/2,arguments/2]).
+-export([firefox/1,firefox/2,firefox/3]).
+-export([sig/1,sig/2,sig/3]).
+-export([funcsf/3]).
+
+stop() ->
+  case whereis(?MODULE) of
+    undefined -> ok;
+    _ -> gen_server:call(?MODULE,stop)
+  end.
+
+start() -> start([]).
+start(Props) -> assert(Props).
+
+distel(link,M,F,A) when ?is_str(M),?is_str(F),is_integer(A) -> 
+  get(link,M,F,A);
+distel(sig,M,F,A) when ?is_str(M),?is_str(F),is_integer(A) ->
+  case get(sig,M,F,A) of
+    [] -> [];
+    no_html -> no_html;
+    Sigs -> {sig, str_join(Sigs,"\n")}
+  end;
+distel(A,B,C,D) ->
+  erlang:display({A,B,C,D}),
+  [].
+
+sig(M) -> sig(M,'').
+sig(M,F) -> sig(M,F,-1).
+sig(M,F,A) when is_atom(M), is_atom(F), is_integer(A) -> get(sig,M,F,A).
+
+firefox(M) -> firefox(M,'').
+firefox(M,F) -> firefox(M,F,-1).
+firefox(M,F,A) when is_atom(M), is_atom(F), is_integer(A) -> 
+  case get(link,M,F,A) of
+    no_html -> no_doc_installed;
+    Link -> ffx(Link)
+  end.
+  
+ffx({link,Link}) -> os:cmd("firefox "++Link),Link;
+ffx({mfas,MFAs}) -> MFAs;
+ffx([]) -> no_doc.
+
+modules(Prefix) -> completions(mods,Prefix,"").
+functions(Mod,Prefix) -> completions(funcs,Mod,Prefix).
+arguments(_Mod,_Fun) -> {ok,""}.
+
+completions(What,M,F) ->
+  case get(What,M,F,"") of
+    no_html -> {error,no_html};
+    [] -> {error,not_found};
+    Ans -> {ok,Ans}
+  end.
+
+get(W,M,F,A) when is_atom(W) ->
+  assert([]),
+  gen_server:call(?MODULE,{W,to_list(M),to_list(F),to_list(A)}).
+
+assert(Props) ->
+  case whereis(?MODULE) of
+    undefined -> gen_server:start({local,?MODULE},?MODULE,Props,[]);
+    Pid -> {ok,Pid}
+  end.
+
+%% --------------------------------------------------------------------------
+%% implementation - runs in the server
+-record(state,{root_dir,prot=file,delim=delim()}).
+
+%% gen_server callbacks
+init(Props) -> 
+  Dir =  proplists:get_value(root_dir, Props, code:root_dir()),
+  Prot = proplists:get_value(prot, Props, file),
+  ets:new(?MODULE,[named_table,ordered_set]),
+  try html_index(Prot,Dir),
+      {ok,#state{root_dir=Dir,prot=Prot}}
+  catch _:_ -> 
+      {ok,no_html}
+  end.
+
+terminate(_,_) -> ok.
+code_change(_,State,_) -> {ok,State}.
+handle_cast(_In,State) -> {noreply,State}.
+handle_info(_In,State) -> {noreply,State}.
+
+handle_call(stop,_From,State) -> 
+  {stop,normal,ok,State};
+handle_call(_In,_From,no_html) ->
+  {reply,no_html,no_html};
+handle_call({sig,M,F,A},_From,State) -> 
+  {reply,handle_sig(M,F,A,State),State};
+handle_call({mods,M,_,_},_From,State) -> 
+  {reply,handle_mods(M,State),State};
+handle_call({funcs,M,F,_},_From,State) -> 
+  {reply,handle_funcs(M,F,State),State};
+handle_call({link,M,F,A},_From,State) -> 
+  {reply,handle_link(M,F,A,State),State}.
+
+%% --------------------------------------------------------------------------
+handle_sig(Mo,Fu,Aa,_State) ->
+  try [get_sig(M,F,A) || {M,F,A} <- matching_mfas(Mo, Fu, Aa)]
+  catch _:_ -> []
+  end.
+
+handle_mods(Prefix,_State) ->
+  try all_prefix_keys({file,Prefix})
+  catch _:_ -> []
+  end.
+
+handle_funcs(Mod,Prefix,_State) ->
+  try [F || {_,F} <- all_fs(Mod,Prefix)]
+  catch _:_ -> []
+  end.
+
+handle_link(Mo,Fu,Aa,State) ->
+  try MFAs = matching_mfas(Mo, Fu, Aa),
+      until([fun()->link_with_anchor(MFAs,State) end,
+	     fun()->exact_match(Mo,Fu,MFAs,State) end,
+	     fun()->link_without_anchor(MFAs,State) end,
+	     fun()->mfa_multi(MFAs,State) end])
+  catch _:_ -> []
+  end.
+
+until([F|Fs]) ->
+  try F()
+  catch _:_ -> until(Fs)
+  end.
+
+link_with_anchor(MFAs,State) -> 
+  [_] = lists:usort([{M,F}||{M,F,_A}<-MFAs]),
+  {A,{M,F}} = lists:min([{A,{M,F}}||{M,F,A}<-MFAs]),
+  {link,io_str("~w://~s#~s~s~s",
+	 [State#state.prot,e_get({file,M}),linkmf(M,F),State#state.delim,A])}.
+
+linkmf("erlang",F) -> "erlang:"++F;
+linkmf(_,F) -> F.
+
+exact_match(M,F,MFAs,State) -> 
+  A = lists:min([A||{Mo,Fu,A}<-MFAs,M==Mo,F==Fu]),
+  {link,io_str("~w://~s#~s~s~s",
+	 [State#state.prot,e_get({file,M}),linkmf(M,F),State#state.delim,A])}.
+
+link_without_anchor(MFAs,State) -> 
+  [M] = lists:usort([M || {M,_F,_A} <- MFAs]),
+  {link,io_str("~w://~s",[State#state.prot, e_get({file,M})])}.
+
+mfa_multi(MFAs,_State) ->
+  {mfas,str_join([io_str("~s:~s/~s",[M,F,A])||{M,F,A}<-MFAs],", ")}.
+
+get_sig(M,F,A) ->
+  Sig = e_get({{sig,M,F},A}),
+  io_str("~s:~s",[M,Sig]).
+
+matching_mfas(Mo, Fu, Aa) ->
+  MFs = lists:append([all_fs(M,Fu) || M <- matching_ms(Mo)]),
+  lists:append([[{M,F,A} || A <- which_a(M,F,Aa)] || {M,F} <- MFs]).
+
+matching_ms(M) ->
+  Ms = all_prefix_keys({file,M}),
+  case lists:member(M,Ms) of 
+    true -> [M];
+    false-> Ms
+  end.
+
+all_fs(Mo,Fu) ->
+  maybe_cache(Mo),
+  [{Mo,F} || F <- all_prefix_keys({{as,Mo},Fu})].
+
+all_prefix_keys({Tag,X}) ->
+  case ets:member(?MODULE,{Tag,X}) of
+    true -> [X|all_prefix_keys({Tag,X},ets:next(?MODULE,{Tag,X}))];
+    false-> all_prefix_keys({Tag,X},ets:next(?MODULE,{Tag,X}))
+  end.
+
+all_prefix_keys({Tag,X0},{Tag,X}) ->
+  case lists:prefix(X0,X) of
+    true -> [X|all_prefix_keys({Tag,X0},ets:next(?MODULE,{Tag,X}))];
+    false-> []
+  end;
+all_prefix_keys(_,_) ->
+  [].
+
+which_a(M,F,"-1") -> 
+  e_get({{as,M},F});
+which_a(M,F,A) ->
+  case lists:member(A,e_get({{as,M},F})) of
+    true -> [A];
+    false-> []
+  end.
+
+%% --------------------------------------------------------------------------
+%% read the index file
+%% store name of html file in {Mod,file}
+html_index(file,Dir) ->
+  FN = filename:join([Dir,"doc","man_index.html"]),
+  fold_file(curry(fun lines/3,Dir),[],FN).
+
+lines(Line,_,Dir) ->
+  case string:tokens(Line, "<> \"") of
+    ["TD", "A", "HREF=", "../"++Href, M|_] -> 
+      case filename:basename(Href,".html") of
+	"index" -> ok;
+	M -> e_set({file,M}, filename:join([Dir,Href]))
+      end;
+    _ -> ok
+  end.
+
+%% --------------------------------------------------------------------------
+%% read a module's html file
+%% store the function names in {fs,Mod}, the arities in {{as,M},F} and the 
+%% function signature in {{sig,M,F},A}
+
+maybe_cache(M) ->
+  try e_get({fs,M}) 
+  catch 
+    no_data -> cache_funcs(M)
+  end.
+
+cache_funcs(M) ->
+  e_set({fs,M},[]),
+  fold_file(curry(fun funcsf/3,M), [], e_get({file,M})).
+
+funcsf(Line,A,M) ->
+  case trim_P(string:tokens(A++Line,"<>\"")) of
+    ["a name=",FA,"span class=","bold_code",Sig,"/span","/a"|_] ->
+      a_line(M,fa(FA),Sig),[];			% R12-
+    ["A NAME=",FA,"STRONG","CODE",Sig,"/CODE","/STRONG","/A"|_] ->
+      a_line(M,fa(FA),Sig),[];			% -R11
+    ["A NAME=",_,"STRONG","CODE"|_] ->
+      A++Line;					% -R11, broken lines
+    _ -> 
+      case A of
+	[] -> [];
+	_ -> A++Line
+      end
+  end.
+
+a_line(_,["Module:"++_,_],_) -> ok;  %ignore the gen_server/gen_fsm callbacks
+a_line("erlang",["erlang:"++F,A],"erlang:"++Sig) -> a_line("erlang",[F,A],Sig);
+a_line(M,[F,A],Sig) ->	    %io:fwrite("- ~p~n",[{M,F,A}]).
+  try e_bag({fs,M},F),
+      e_bag({{as,M},F}, A),
+      e_set({{sig,M,F},A}, dehtml(Sig))
+  catch _:_ -> ok
+  end.
+
+fa(FA) -> string:tokens(FA,delim()).
+
+trim_P([_,"P"|L]) -> L;
+trim_P([_,"p"|L]) -> L;
+trim_P(["P"|L])   -> L;
+trim_P(["p"|L])   -> L;
+trim_P(L)         -> L.
+
+delim() ->
+  try erlang:system_info(otp_release), "-"
+  catch _:_ -> "/"
+  end.
+
+%% --------------------------------------------------------------------------
+%% ets-based dictionary
+e_set(Key,Val) -> ets:insert(?MODULE,{Key,Val}).
+
+e_get(Key) ->
+  case ets:lookup(?MODULE,Key) of
+    [{Key,Val}] -> Val;
+    [] -> throw(no_data);
+    X -> exit({bad_e_get,{table,?MODULE},{key,Key},{value,X}})
+  end.
+
+e_bag(Key,Val) ->
+  try e_get(Key) of
+    L when is_list(L) -> e_set(Key,[Val|L]);
+    X                 -> exit({bad_e_bag,{table,?MODULE},{key,Key},{value,X}})
+  catch
+    no_data -> e_set(Key,[Val])
+  end.
+
+%% --------------------------------------------------------------------------
+%% the missing fold_file/3 function
+fold_file(Fun,Acc0,File) ->
+  {ok, FD} = file:open(File, [read]),
+  Acc = fold_file_lines(FD,Fun,Acc0),
+  file:close(FD),
+  Acc.
+
+fold_file_lines(FD,Fun,Acc) ->
+  case io:get_line(FD, "") of
+    eof -> Acc;
+    Line -> fold_file_lines(FD,Fun,Fun(trim_nl(Line),Acc))
+  end.
+
+trim_nl(Str) -> lists:reverse(tl(lists:reverse(Str))).
+  
+%% --------------------------------------------------------------------------
+%% Schönfinkelisation
+curry(F,Arg) ->
+  case erlang:fun_info(F,arity) of
+    %% {_,1} -> fun() -> F(Arg) end;
+    %% {_,2} -> fun(A) -> F(A,Arg) end;
+    {_,3} -> fun(A,B) -> F(A,B,Arg) end
+    %% {_,4} -> fun(A,B,C) -> F(A,B,C,Arg) end
+  end.
+
+%% --------------------------------------------------------------------------
+io_str(F,A) -> lists:flatten(io_lib:format(F,A)).
+
+%% dehtmlize right angle
+dehtml("&#62;"++Str) -> ">"++dehtml(Str);
+dehtml("&gt;"++Str)  -> ">"++dehtml(Str);
+dehtml([H|Str])      -> [H|dehtml(Str)];
+dehtml("")           -> "".
+
+str_join([], _Sep) -> "";
+str_join([Pref|Toks], Sep) ->
+  lists:foldl(fun(Tok,O) -> O++Sep++Tok end, Pref, Toks).
+
+to_list(A) when is_atom(A) -> atom_to_list(A);
+to_list(I) when is_integer(I)-> integer_to_list(I);
+to_list(S) when ?is_str(S) -> S.


### PR DESCRIPTION
Updated to latest distel with our patches, adding missing elisp/erl files and requiring/initializing distel on startup

NOTE: This patch removes the old local hack in erl-service.el: "(unless distel-inhibit-backend-check)" -> "(unless t ; ...)", so a workaround should be made in the Wrangler code instead (ensuring that the distel.erl module is already loaded).
