### PR TITLE
ensure derl.el is exactly the same as in latest distel

### DIFF
--- a/elisp/derl.el
+++ b/elisp/derl.el
@@ -225,8 +225,7 @@ gen_digest() function:
 	(insert-file-contents (concat (getenv "HOME") "/.erlang.cookie"))
 	(while (search-forward "\n" nil t)
 	  (replace-match ""))
-        (buffer-string))))
- 
+	(buffer-string))))
 
 ;; ------------------------------------------------------------
 ;; Alive/connected state


### PR DESCRIPTION
After this, all the distel files shipped with wrangler are up to date with the latest distel. There are no wrangler-specific patches anymore (apart from some @private edoc-annotations to prevent the distel .erl files to show up in the wrangler documentation).
