### PR TITLE
Quote $ERL and $ERLC commands, so they work even if their paths contains 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,8 +5,8 @@ prefix       = @prefix@
 exec_prefix  = @exec_prefix@
 libdir       = @libdir@
 LIB_DIR      = @ERLANG_INSTALL_LIB_DIR@/$(APPNAME)-$(VERSION)
-ERL          = @ERL@
-ERLC         = @ERLC@
+ERL          = "@ERL@"
+ERLC         = "@ERLC@"
 
 DOC_OPTS={def,{version,\"$(VERSION)\"}}
 


### PR DESCRIPTION
Quote $ERL and $ERLC commands, so they work even if their paths contains whitespaces
