### PR TITLE
fix a startup timing problem

### DIFF
--- a/elisp/wrangler.el
+++ b/elisp/wrangler.el
@@ -446,12 +446,13 @@
   (sleep-for 1.0)
   (save-window-excursion
     (wrangler-erlang-shell))
-  (sleep-for 2.0)
+  (sleep-for 1.0)
   (erl-spawn
     (erl-send-rpc wrangler-erl-node 'code 'ensure_loaded (list 'distel))
     (erl-receive()
         ((['rex res]
           t))))
+  (sleep-for 1.0)
   (start-wrangler-app))
   
 


### PR DESCRIPTION
Without a delay before start-wrangler-app, I can't start Wrangler anymore - I keep getting "failed to start:[not_started kernel]" errors. On the other hand, the 2 second delay before it seemed unnecessarily long; I reduced it to 1 second without any apparent problems.
