### PR TITLE
Allow all editor options in two places

### DIFF
--- a/src/refac_new_fun.erl
+++ b/src/refac_new_fun.erl
@@ -96,7 +96,10 @@ fun_extraction_1(FileName, AnnAST, End, Fun, ExpList, NewFunName, Editor, TabWid
 	    wrangler_write_file:write_refactored_files(Res, false, Editor, TabWidth, Cmd);
 	eclipse ->
             wrangler_write_file:write_refactored_files(
-              Res, Editor, TabWidth, "")
+		Res, Editor, TabWidth, "");
+	command ->
+	    wrangler_write_file:write_refactored_files(
+		Res, Editor, TabWidth, Cmd)
     end.
 
 get_free_bd_vars(ExpList) ->

--- a/src/refac_new_macro.erl
+++ b/src/refac_new_macro.erl
@@ -281,7 +281,10 @@ return_refac_result(FileName, AnnAST, Editor, Cmd, TabWidth) ->
 	    {ok, [FileName]};
 	eclipse ->
             wrangler_write_file:write_refactored_files(
-                [{{FileName, FileName}, AnnAST}], Editor, TabWidth, "")
+                [{{FileName, FileName}, AnnAST}], Editor, TabWidth, "");
+	_ ->
+	    wrangler_write_file:write_refactored_files(
+                [{{FileName, FileName}, AnnAST}], Editor, TabWidth, Cmd)
     end.
 
 rewrite(Source, Target) ->

--- a/src/wrangler_module_graph.erl
+++ b/src/wrangler_module_graph.erl
@@ -325,7 +325,7 @@ is_scc_edge({V1, V2}, Sccs) ->
 	      end, Sccs).
 
 node_format(V, Sccs) ->
-    String = io_lib:format("~p", [V]),
+    String = io_lib:format("\"~p\"", [V]),
     {Width, Heigth} = calc_dim(String),
     W = (Width div 7 + 1) * 0.55,
     H = Heigth * 0.4,
@@ -353,29 +353,27 @@ edge_format([],_,_,_) ->
 edge_format(_,[],_,_) ->
     "";
 edge_format(V1, V2, Label, WithLabel) ->
-    String = [io_lib:format("~p", [V1]), " -> ",
-	      io_lib:format("~p", [V2])],
-    case WithLabel of 
+    String = [io_lib:format("\"~p\"", [V1]), " -> ",
+	      io_lib:format("\"~p\"", [V2])],
+    case WithLabel of
 	true ->
 	    [String, " [", "label=", "\"", format_label(Label),  "\"", "];\n"];
 	_ ->
 	    [String, " [", "];\n"]
     end.
-  
+
 
 format_label([]) ->
     "";
 format_label([{F,A}|T]) ->
-    case T of 
+    case T of
 	[] ->
 	    io_lib:format("~p/~p.", [F, A]);
 	[{F1, A1}|T1] ->
-	    case T1 of 
+	    case T1 of
 		[] ->
 		    io_lib:format("~p/~p,~p/~p,", [F, A, F1, A1])++format_label(T1);
 		_ ->
 		    io_lib:format("~p/~p,~p/~p,", [F, A, F1, A1])++"\\n"++format_label(T1)
 		end
     end.
-
-


### PR DESCRIPTION
i.e. refac_new_fun:fun_extraction_1/9 and
refac_new_macro:return_refac_result/5.

The motivation is to provide an option (e.g. by passing `command') to
overwrite the original files directly.