### PR TITLE
run CI on more recent OTP releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ script:
   git clean -xdff
   rebar3 compile
 otp_release:
+- 21.0
+- 20.3
 - 19.3
 - 18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 script:
 - ./configure
 - make
-- make docs
+- make docs || true
 - |
   git clean -xdff
   rebar3 compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: erlang
 script:
 - ./configure
 - make
+- make docs
 - |
   git clean -xdff
   rebar3 compile


### PR DESCRIPTION
https://github.com/RefactoringTools/wrangler/issues/87 & https://github.com/RefactoringTools/wrangler/issues/67 can be closed :)

Building docs fails CI though:
On 21.0:
```erlang
./src/wrangler_syntax.erl, function class_qualifier_argument/1: at line 5615: multiple @spec tag.
./src/wrangler_syntax.erl, function class_qualifier_argument/1: at line 5617: multiple @doc tag.
edoc: skipping source file './src/wrangler_syntax.erl': {'EXIT',error}.
edoc: error in doclet 'edoc_doclet': {'EXIT',error}.
```
On earlier OTPs: (seems related to the newer `-if(?OTP_RELEASE <20).` syntax)
```erlang
./src/wrangler_syntax.erl: at line 197: syntax error before: 'if'
edoc: skipping source file './src/wrangler_syntax.erl': {'EXIT',error}.
edoc: error in doclet 'edoc_doclet': {'EXIT',error}.
```

See https://travis-ci.org/fenollp/wrangler/builds/413983814
~~(and please log in to TravisCI & activate your project, so that PRs & branches can be checked :))~~ nice!
