### PR TITLE
Use valid function name placeholder when extracting functions

### DIFF
--- a/src/wls/wls_code_action_new_fun.erl
+++ b/src/wls/wls_code_action_new_fun.erl
@@ -45,8 +45,8 @@ execute_command([#{ <<"range">> := Range
                 }]) ->
   {StartPos, EndPos} = wls_utils:range(Range),
   Path = wls_utils:path(Uri),
-  ?LOG_INFO("Using default variable name: NewFun"),
-  new_fun(Path, StartPos, EndPos, "NewFun"),
+  ?LOG_INFO("Using default function name: newFun"),
+  new_fun(Path, StartPos, EndPos, "newFun"),
   [].
 
 


### PR DESCRIPTION
This is a completely untested, wild guess, coming from: https://github.com/erlang-ls/erlang_ls/issues/1367